### PR TITLE
Respect synonyms when calculating filenames

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*       text=auto
+*.sh    text        eol=lf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+# For running container dependencies locally
+services:
+  redis:
+    image: redis
+    ports:
+      - 6379:6379

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@typescript-eslint/parser": "^8.26.1",
         "chokidar-cli": "^3.0.0",
         "concurrently": "^9.1.2",
+        "cross-env": "^7.0.3",
         "eslint": "^9.22.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -3389,6 +3390,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:both": "concurrently \"npm run build:backend\" \"npm run build:frontend\"",
     "serve:frontend": "cd frontend && npm run serve",
     "start": "node dist/server.js",
-    "dev": "DEBUG=true concurrently \"nodemon src/server.ts\" \"npm run serve:frontend\"",
+    "dev": "cross-env DEBUG=true concurrently \"nodemon src/server.ts\" \"npm run serve:frontend\"",
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "jamie": "ts-node src/jamieTest.ts"
@@ -56,6 +56,7 @@
     "@typescript-eslint/parser": "^8.26.1",
     "chokidar-cli": "^3.0.0",
     "concurrently": "^9.1.2",
+    "cross-env": "^7.0.3",
     "eslint": "^9.22.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/src/service/episodeCacheService.ts
+++ b/src/service/episodeCacheService.ts
@@ -7,7 +7,7 @@ import { IPlayerSearchResult, VideoType } from '../types/IPlayerSearchResult';
 import { QueuedStorage } from '../types/QueuedStorage'
 import { EpisodeCacheDefinition } from '../types/responses/EpisodeCacheTypes';
 import { IPlayerChilrenResponse, IPlayerMetadataResponse } from '../types/responses/IPlayerMetadataResponse';
-import { createNZBName, getQualityPofile, removeAllQueryParams, splitArrayIntoChunks } from '../utils/Utils';
+import { createNZBName, getQualityProfile, removeAllQueryParams, splitArrayIntoChunks } from '../utils/Utils';
 import iplayerService from './iplayerService';
 
 
@@ -123,7 +123,7 @@ const episodeCacheService = {
 
     cacheEpisodesForUrl : async (inputUrl : string) : Promise<boolean> => {
         await episodeCacheService.initStorage();
-        const {sizeFactor} = await getQualityPofile();
+        const {sizeFactor} = await getQualityProfile();
 
         const url = removeAllQueryParams(inputUrl);
 

--- a/src/service/iplayerService.ts
+++ b/src/service/iplayerService.ts
@@ -14,7 +14,7 @@ import { QueueEntry } from '../types/QueueEntry';
 import { IPlayerNewSearchResponse } from '../types/responses/iplayer/IPlayerNewSearchResponse';
 import { IPlayerChilrenResponse } from '../types/responses/IPlayerMetadataResponse';
 import { Synonym } from '../types/Synonym';
-import { createNZBName, getQualityPofile, splitArrayIntoChunks } from '../utils/Utils';
+import { createNZBName, getQualityProfile, splitArrayIntoChunks } from '../utils/Utils';
 import configService from './configService';
 import episodeCacheService from './episodeCacheService';
 import historyService from './historyService';
@@ -241,7 +241,7 @@ const iplayerService = {
     },
 
     nativeSearch: async (term: string, synonym?: Synonym): Promise<IPlayerSearchResult[]> => {
-        const { sizeFactor } = await getQualityPofile();
+        const { sizeFactor } = await getQualityProfile();
 
         const url = `https://ibl.api.bbc.co.uk/ibl/v1/new-search?q=${encodeURIComponent(synonym?.target ?? term)}`;
 
@@ -286,7 +286,7 @@ const iplayerService = {
     },
 
     getIplayerSearch : async(term: string, synonym?: Synonym) : Promise<IPlayerSearchResult[]> => {
-        const { sizeFactor } = await getQualityPofile();
+        const { sizeFactor } = await getQualityProfile();
         return new Promise(async (resolve, reject) => {
             const results: IPlayerSearchResult[] = []
             const [exec, args] = await getIPlayerExec();

--- a/src/service/iplayerService.ts
+++ b/src/service/iplayerService.ts
@@ -279,7 +279,7 @@ const iplayerService = {
             }
 
             // const infos = await iplayerService.details(resultPids);
-            return await Promise.all(infos.map((info: IPlayerDetails) => createResult(info.title, info, sizeFactor)));
+            return await Promise.all(infos.map((info: IPlayerDetails) => createResult(info.title, info, sizeFactor, synonym)));
         } else {
             return [];
         }
@@ -405,15 +405,16 @@ function removeLastFourDigitNumber(str: string) {
     return str.replace(/\d{4}(?!.*\d{4})/, '').trim();
 }
 
-async function createResult(term: string, details: IPlayerDetails, sizeFactor: number): Promise<IPlayerSearchResult> {
+async function createResult(term: string, details: IPlayerDetails, sizeFactor: number, synonym: Synonym | undefined): Promise<IPlayerSearchResult> {
     const size: number | undefined = details.runtime ? (details.runtime * 60) * sizeFactor : undefined;
 
     const type: VideoType = details.episode && details.series ? VideoType.TV : VideoType.MOVIE;
-
+    const synonymName = synonym ? (synonym.filenameOverride || synonym.from).replaceAll(/[^a-zA-Z0-9\s.]/g, '').replaceAll(' ', '.') : undefined;
     const nzbName = await createNZBName(type, {
         title: details.title.replaceAll(' ', '.'),
         season: details.series ? details.series.toString().padStart(2, '0') : undefined,
         episode: details.episode ? details.episode.toString().padStart(2, '0') : undefined,
+        synonym: synonymName
     });
 
     return {
@@ -428,7 +429,7 @@ async function createResult(term: string, details: IPlayerDetails, sizeFactor: n
         episode: details.episode,
         pubDate: details.firstBroadcast ? new Date(details.firstBroadcast) : undefined,
         series: details.series,
-        type: VideoType.TV,
+        type,
         size,
         nzbName
     }

--- a/src/service/iplayerService.ts
+++ b/src/service/iplayerService.ts
@@ -278,8 +278,8 @@ const iplayerService = {
                 infos = [...infos, ...chunkInfos];
             }
 
-            // const infos = await iplayerService.details(resultPids);
-            return await Promise.all(infos.map((info: IPlayerDetails) => createResult(info.title, info, sizeFactor, synonym)));
+            const synonymName = synonym ? (synonym.filenameOverride || synonym.from).replaceAll(/[^a-zA-Z0-9\s.]/g, '').replaceAll(' ', '.') : undefined;
+            return await Promise.all(infos.map((info: IPlayerDetails) => createResult(info.title, info, sizeFactor, synonymName)));
         } else {
             return [];
         }
@@ -405,11 +405,10 @@ function removeLastFourDigitNumber(str: string) {
     return str.replace(/\d{4}(?!.*\d{4})/, '').trim();
 }
 
-async function createResult(term: string, details: IPlayerDetails, sizeFactor: number, synonym: Synonym | undefined): Promise<IPlayerSearchResult> {
+async function createResult(term: string, details: IPlayerDetails, sizeFactor: number, synonymName: string | undefined): Promise<IPlayerSearchResult> {
     const size: number | undefined = details.runtime ? (details.runtime * 60) * sizeFactor : undefined;
 
     const type: VideoType = details.episode && details.series ? VideoType.TV : VideoType.MOVIE;
-    const synonymName = synonym ? (synonym.filenameOverride || synonym.from).replaceAll(/[^a-zA-Z0-9\s.]/g, '').replaceAll(' ', '.') : undefined;
     const nzbName = await createNZBName(type, {
         title: details.title.replaceAll(' ', '.'),
         season: details.series ? details.series.toString().padStart(2, '0') : undefined,

--- a/src/service/synonymService.ts
+++ b/src/service/synonymService.ts
@@ -14,9 +14,11 @@ if (process.env.STORAGE_LOCATION){
 
 
 const synonymService = {
-    getSynonym : async (from : string) : Promise<Synonym | undefined> => {
+    getSynonym : async (inputTerm : string) : Promise<Synonym | undefined> => {
         const allSynonyms = await synonymService.getAllSynonyms();
-        return allSynonyms.find(({from : savedFrom}) => savedFrom.toLocaleLowerCase() == from.toLocaleLowerCase());
+        return allSynonyms.find(({from : savedFrom, target : savedTarget }) => 
+            savedFrom.toLocaleLowerCase() == inputTerm.toLocaleLowerCase() ||
+            savedTarget.toLocaleLowerCase() == inputTerm.toLocaleLowerCase());
     },
 
     getAllSynonyms : async () : Promise<Synonym[]> => {

--- a/src/service/synonymService.ts
+++ b/src/service/synonymService.ts
@@ -16,7 +16,7 @@ if (process.env.STORAGE_LOCATION){
 const synonymService = {
     getSynonym : async (from : string) : Promise<Synonym | undefined> => {
         const allSynonyms = await synonymService.getAllSynonyms();
-        return allSynonyms.find(({from : savedFrom}) => savedFrom == from);
+        return allSynonyms.find(({from : savedFrom}) => savedFrom.toLocaleLowerCase() == from.toLocaleLowerCase());
     },
 
     getAllSynonyms : async () : Promise<Synonym[]> => {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -19,7 +19,7 @@ export function formatBytes(bytes: number, unit: boolean = true, decimals: numbe
 }
 
 export async function createNZBName(type: VideoType, context: FilenameTemplateContext) {
-    context.quality = (await getQualityPofile()).quality;
+    context.quality = (await getQualityProfile()).quality;
     const templateKey: IplayarrParameter = type == VideoType.MOVIE ? IplayarrParameter.MOVIE_FILENAME_TEMPLATE : IplayarrParameter.TV_FILENAME_TEMPLATE;
     const template = await configService.getParameter(templateKey) as string;
     return Handlebars.compile(template)(context);
@@ -37,7 +37,7 @@ export function createNZBDownloadLink({ pid, nzbName, type }: IPlayerSearchResul
     return `/api?mode=nzb-download&pid=${pid}&nzbName=${nzbName}&type=${type}&apikey=${apiKey}${app ? `&app=${app}` : ''}`
 }
 
-export async function getQualityPofile(): Promise<QualityProfile> {
+export async function getQualityProfile(): Promise<QualityProfile> {
     const videoQuality = await configService.getParameter(IplayarrParameter.VIDEO_QUALITY) as string;
     return qualityProfiles.find(({ id }) => id == videoQuality) as QualityProfile;
 }


### PR DESCRIPTION
Pass the synonym down to `createNZBName` so it can be used in the filename template. I've also adjusted the synonym lookup to match on `target` as well as `from` so we can respect the synonym for direct searches for the correct iPlayer title and made it case-insensitive to aid with manual searches directly within iPlayarr:

![Search results respecting the synonym naming convention](https://github.com/user-attachments/assets/099368f5-85e6-4663-9e80-e0ed2ccb715f)

![Show details are unaffected by changes beyond the filename](https://github.com/user-attachments/assets/35461b83-c146-4e59-a90a-14cfd821b28f)

Happy to revert that particular change if you think it may cause issues. There are also a couple of minor tweaks to run locally on Windows.

Closes #88.