### PR TITLE
Correct MB/s to Mb/s in Queue Page

### DIFF
--- a/frontend/src/components/queue/QueueTableRow.vue
+++ b/frontend/src/components/queue/QueueTableRow.vue
@@ -42,7 +42,7 @@
       {{ item.details.eta }}
     </td>
     <td data-title="Speed">
-      {{ item.details.speed || '' }} {{ item.details.speed != '' ? 'MB/s' : '' }}
+      {{ item.details.speed || '' }} {{ item.details.speed != '' ? 'Mb/s' : '' }}
     </td>
     <td class="actionCol" data-title="Action">
       <span>


### PR DESCRIPTION
The queue page is using the wrong descriptor for speed (Megabytes rather than Megabits).  This can be validated by oberserving the download queue vs the log.