### PR TITLE
Floor runtimes when we multiply by sizeFactor

### DIFF
--- a/src/service/episodeCacheService.ts
+++ b/src/service/episodeCacheService.ts
@@ -176,7 +176,7 @@ const episodeCacheService = {
 }
 
 async function createResult(term : string, details : IPlayerDetails, sizeFactor : number) : Promise<IPlayerSearchResult> {
-    const size : number | undefined = details.runtime ? ((details.runtime * 60) * sizeFactor) / 100 : undefined;
+    const size : number | undefined = details.runtime ? Math.floor((details.runtime * 60 * sizeFactor) / 100) : undefined;
     const nzbName = await createNZBName(details);
     return {
         number: 0,

--- a/src/service/getIplayerExecutableService.ts
+++ b/src/service/getIplayerExecutableService.ts
@@ -157,6 +157,7 @@ export class GetIplayerExecutableService {
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const [_, pid, rawTitle, seriesStr, episodeStr, number, channel, durationStr, onlineFrom, epTitle] = line.split('|:|');
                 const [ title, episodeNum, seriesNum ] = parseEpisodeDetailStrings(rawTitle, episodeStr, seriesStr)
+                const duration = durationStr != '' ? parseInt(durationStr) : undefined;
                 const [ type, episode, episodeTitle, series ] = calculateSeasonAndEpisode({
                     type: 'episode',
                     pid,
@@ -182,7 +183,7 @@ export class GetIplayerExecutableService {
                     episode,
                     series,
                     type,
-                    size: durationStr ? parseInt(durationStr) * sizeFactor : undefined,
+                    size: duration == null || isNaN(duration) ? undefined : Math.floor(duration * sizeFactor),
                     pubDate: onlineFrom ? new Date(onlineFrom) : undefined,
                     episodeTitle
                 });

--- a/src/service/searchService.ts
+++ b/src/service/searchService.ts
@@ -128,7 +128,7 @@ export class SearchService {
             pubDate: details.firstBroadcast ? new Date(details.firstBroadcast) : undefined,
             series: details.series,
             type: details.type,
-            size: details.runtime ? (details.runtime * 60) * sizeFactor : undefined,
+            size: details.runtime ? Math.floor(details.runtime * 60 * sizeFactor) : undefined,
             nzbName: await createNZBName(details, synonym),
             episodeTitle: details.episodeTitle
         }


### PR DESCRIPTION
![{E7B325A8-0840-4944-B317-78BA904F03B6}](https://github.com/user-attachments/assets/ca3b0460-2ef2-45be-b1a7-20178d1f555b)

Closes #112.