### PR TITLE
Handle titles with colons, clear cache on Native Search toggle

### DIFF
--- a/src/service/configService.ts
+++ b/src/service/configService.ts
@@ -2,6 +2,7 @@ import dotenv from 'dotenv'
 
 import { IplayarrParameter } from '../types/IplayarrParameters';
 import { QueuedStorage } from '../types/QueuedStorage'
+import searchService from './searchService';
 
 
 dotenv.config();
@@ -55,8 +56,12 @@ const configService = {
 
     setParameter : async (parameter: IplayarrParameter, value : string) : Promise<void> => {
         const configMap = await getConfigMap();
+        const oldValue = configMap[parameter];
         configMap[parameter] = value;
         await storage.setItem('config', configMap);
+        if (parameter == IplayarrParameter.NATIVE_SEARCH && oldValue != value) {
+            searchService.clearSearchCache();
+        }
     },
 
     removeParameter : async (parameter: IplayarrParameter) : Promise<void> => {

--- a/src/service/redisCacheService.ts
+++ b/src/service/redisCacheService.ts
@@ -28,4 +28,9 @@ export default class RedisCacheService<T> {
     async del(key : string) : Promise<void> {
         await redis.del(`${this.prefix}_${key}`);
     }
+
+    async clear() : Promise<void> {
+        const keys = await redis.keys(`${this.prefix}_*`);
+        await redis.del(keys);
+    }
 }

--- a/src/service/searchService.ts
+++ b/src/service/searchService.ts
@@ -137,6 +137,10 @@ export class SearchService {
     removeFromSearchCache(term: string) {
         this.searchCache.del(term);
     }
+
+    clearSearchCache() {
+        this.searchCache.clear();
+    }
 }
 
 export default new SearchService();

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -82,7 +82,11 @@ export function parseEpisodeDetailStrings(title: string, episode?: string, serie
     const episodeNum = parseInt(episode ?? '')
     const seriesMatch = getIplayerSeriesRegex.exec(title);
     const seriesNum = parseInt(seriesMatch ? seriesMatch[1] : series ?? '')
-    return [title.replace(getIplayerSeriesRegex, '').split(': ')[0], isNaN(episodeNum) ? undefined : episodeNum, isNaN(seriesNum) ? undefined : seriesNum];
+    return [
+        title.replace(getIplayerSeriesRegex, ''),
+        isNaN(episodeNum) ? undefined : episodeNum,
+        isNaN(seriesNum) ? undefined : seriesNum
+    ];
 }
 
 export function getPotentialRoman(str: string): number {

--- a/tests/service/searchService.test.ts
+++ b/tests/service/searchService.test.ts
@@ -37,6 +37,12 @@ jest.mock('src/service/redisCacheService', () => {
         del: jest.fn((key: string) => {
             delete mockCacheData[key];
             return Promise.resolve();
+        }),
+        clear: jest.fn(() => {
+            Object.keys(mockCacheData).forEach((key: string) => {
+                delete mockCacheData[key];
+            });
+            return Promise.resolve();
         })
     };
     return {
@@ -127,5 +133,25 @@ describe('searchService', () => {
 
         expect(synonymService.getSynonym).toHaveBeenCalledWith(term);
         expect(iplayerService.performSearch).toHaveBeenCalledWith('targetTerm', synonym);
+    });
+
+    it('can remove a single entry from the cache', () => {
+        mockCacheData['show1'] = '{}';
+        mockCacheData['show2'] = '{}';
+
+        searchService.removeFromSearchCache('show1');
+
+        expect(mockCacheData['show1']).toBeUndefined();
+        expect(mockCacheData['show2']).toBe('{}')
+    });
+
+    it('can clear the entire cache', () => {
+        mockCacheData['show1'] = '{}';
+        mockCacheData['show2'] = '{}';
+
+        searchService.clearSearchCache();
+
+        expect(mockCacheData['show1']).toBeUndefined();
+        expect(mockCacheData['show2']).toBeUndefined();
     });
 });

--- a/tests/utils/Utils.test.ts
+++ b/tests/utils/Utils.test.ts
@@ -273,6 +273,20 @@ describe('Utils', () => {
             expect(episode).toBeUndefined();
             expect(series).toBeUndefined();
         })
+        
+        it('extracts titles with special characters', () => {
+            const [title, episode, series] = Utils.parseEpisodeDetailStrings('The Apprentice: You\'re Fired!: Series 19', '12', '1');
+            expect(title.trim()).toBe('The Apprentice: You\'re Fired!');
+            expect(episode).toBe(12);
+            expect(series).toBe(19);
+        });
+        
+        it('fall back still extracts titles with special characters', () => {
+            const [title, episode, series] = Utils.parseEpisodeDetailStrings('The Apprentice: You\'re Fired!', '12', '19');
+            expect(title.trim()).toBe('The Apprentice: You\'re Fired!');
+            expect(episode).toBe(12);
+            expect(series).toBe(19);
+        });
     });
     
     describe('getPotentialRoman', () => {


### PR DESCRIPTION
Should fix searching for "The Apprentice: You're Fired!", which I spotted whilst testing the issue in #114. Since it is already doing the regex replacement, we don't need to then further split by `: `, just return the result. I've also set it to clear the search cache when toggling Native Search, which removes false positives and such.