### PR TITLE
Look up synonyms for get_iplayer results

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 4
+max_line_length = 120

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+    "singleQuote": true,
+    "trailingComma": "es5"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "ms-azuretools.vscode-docker",
+        "orta.vscode-jest",
+        "vue.volar"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,22 @@
 {
-    "html.format.wrapLineLength": 600,
+    "editor.codeActionsOnSave": {
+        "source.fixAll": "explicit"
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.formatOnSaveMode": "modificationsIfAvailable",
+    "editor.guides.indentation": true,
+    "editor.rulers": [120],
+    "eslint.validate": ["javascript", "javascriptvue", "typescript", "typescriptvue"],
     "eslint.workingDirectories": [
         {
             "mode": "auto"
         }
     ],
+    "files.eol": "\n",
+    "html.format.wrapLineLength": 120,
     "jest.runMode": {
-        "type": "on-save",
-        "coverage": true
-    },
+        "coverage": true,
+        "type": "on-save"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,8 @@
             "mode": "auto"
         }
     ],
+    "jest.runMode": {
+        "type": "on-save",
+        "coverage": true
+    },
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,27 +1,26 @@
 import pluginJs from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier/flat';
 import importPlugin from 'eslint-plugin-import';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
-import pluginVue from 'eslint-plugin-vue'
+import pluginVue from 'eslint-plugin-vue';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
     { files: ['**/*.{ts,vue}', 'frontend/src/**/*.{js}'] },
-    { languageOptions: { globals: {...globals.node, ...globals.browser} } },
+    { languageOptions: { globals: { ...globals.node, ...globals.browser } } },
     pluginJs.configs.recommended,
     ...tseslint.configs.recommended,
     ...pluginVue.configs['flat/recommended'],
     { ignores: ['**/dist/**', '**/node_modules/**'] },
-
-    // Enable sorting and enforce single quotes
     {
         plugins: {
             import: importPlugin,
-            'simple-import-sort': simpleImportSort
+            'simple-import-sort': simpleImportSort,
         },
         rules: {
-            'indent' : [ 'error', 4 ],
+            indent: ['error', 4],
             '@typescript-eslint/no-explicit-any': 'off',
             'no-useless-catch': 'off',
             'no-async-promise-executor': 'off',
@@ -29,7 +28,13 @@ export default [
             'simple-import-sort/exports': 'error',
             'vue/max-attributes-per-line': 'off',
             'vue/require-default-prop': 'off',
-            'quotes': ['error', 'single'],
-        }
-    }
+        },
+    },
+    eslintConfigPrettier,
+    {
+        // Override Prettier disabling specific rules
+        rules: {
+            quotes: ['error', 'single'],
+        },
+    },
 ];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,9 +30,11 @@
         "@vue/cli-plugin-pwa": "~5.0.0",
         "@vue/cli-service": "~5.0.0",
         "eslint": "^7.32.0",
+        "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-vue": "^8.0.3",
         "less": "^4.2.2",
-        "less-loader": "^12.2.0"
+        "less-loader": "^12.2.0",
+        "prettier": "^3.5.3"
       }
     },
     "node_modules/@achrinza/node-ipc": {
@@ -3244,6 +3246,23 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
+    "node_modules/@vue/component-compiler-utils/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@vue/component-compiler-utils/node_modules/yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
@@ -6388,6 +6407,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
+      "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-vue": {
@@ -11152,17 +11184,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,9 +30,11 @@
     "@vue/cli-plugin-pwa": "~5.0.0",
     "@vue/cli-service": "~5.0.0",
     "eslint": "^7.32.0",
+    "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-vue": "^8.0.3",
     "less": "^4.2.2",
-    "less-loader": "^12.2.0"
+    "less-loader": "^12.2.0",
+    "prettier": "^3.5.3"
   },
   "eslintConfig": {
     "root": true,
@@ -41,7 +43,8 @@
     },
     "extends": [
       "plugin:vue/vue3-essential",
-      "eslint:recommended"
+      "eslint:recommended",
+      "plugin:prettier/recommended"
     ],
     "parserOptions": {
       "parser": "@babel/eslint-parser"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "extends": [
       "plugin:vue/vue3-essential",
       "eslint:recommended",
-      "plugin:prettier/recommended"
+      "prettier"
     ],
     "parserOptions": {
       "parser": "@babel/eslint-parser"

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "concurrently": "^9.1.2",
         "cross-env": "^7.0.3",
         "eslint": "^9.22.0",
+        "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-vue": "^10.0.0",
@@ -56,6 +57,7 @@
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",
         "nodemon": "^3.1.9",
+        "prettier": "^3.5.3",
         "ts-jest": "^29.2.6",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.3",
@@ -4057,6 +4059,19 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
+      "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -7717,6 +7732,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:watch": "jest --watch",
     "lint": "eslint . --ext .ts",
     "lint:fix": "npm run lint -- --fix",
-    "jamie": "ts-node src/jamieTest.ts"
+    "prettier": "prettier . --check",
+    "prettier:fix": "npm run prettier -- --write"
   },
   "author": "",
   "license": "ISC",
@@ -59,6 +60,7 @@
     "concurrently": "^9.1.2",
     "cross-env": "^7.0.3",
     "eslint": "^9.22.0",
+    "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-vue": "^10.0.0",
@@ -67,6 +69,7 @@
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "nodemon": "^3.1.9",
+    "prettier": "^3.5.3",
     "ts-jest": "^29.2.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3",

--- a/src/service/getIplayerExecutableService.ts
+++ b/src/service/getIplayerExecutableService.ts
@@ -16,6 +16,7 @@ import historyService from './historyService';
 import loggingService from './loggingService';
 import queueService from './queueService';
 import socketService from './socketService';
+import synonymService from './synonymService';
 
 export class GetIplayerExecutableService {
     async getIPlayerExec(): Promise<GetIPlayerExecutable> {
@@ -83,7 +84,6 @@ export class GetIplayerExecutableService {
     }
 
     logProgress(pid: string, data : any) {
-        console.log(data.toString());
         const logLine: LogLine = { level: LogLineLevel.INFO, id: pid, message: data.toString(), timestamp: new Date() }
         socketService.emit('log', logLine);
     }
@@ -194,7 +194,8 @@ export class GetIplayerExecutableService {
 
     async processCompletedSearch(results : IPlayerSearchResult[], synonym? : Synonym) : Promise<IPlayerSearchResult[]> {
         for (const result of results) {
-            result.nzbName = await createNZBName(result, synonym);
+            const resultSynonym = synonym ?? await synonymService.getSynonym(result.title);
+            result.nzbName = await createNZBName(result, resultSynonym);
         }
         return results;
     }

--- a/src/service/getIplayerExecutableService.ts
+++ b/src/service/getIplayerExecutableService.ts
@@ -84,6 +84,7 @@ export class GetIplayerExecutableService {
     }
 
     logProgress(pid: string, data : any) {
+        console.log(data.toString());
         const logLine: LogLine = { level: LogLineLevel.INFO, id: pid, message: data.toString(), timestamp: new Date() }
         socketService.emit('log', logLine);
     }

--- a/src/service/redisCacheService.ts
+++ b/src/service/redisCacheService.ts
@@ -31,6 +31,8 @@ export default class RedisCacheService<T> {
 
     async clear() : Promise<void> {
         const keys = await redis.keys(`${this.prefix}_*`);
-        await redis.del(keys);
+        if (keys.length) {
+            await redis.del(keys);
+        }
     }
 }

--- a/tests/service/getIplayerExecutableService.test.ts
+++ b/tests/service/getIplayerExecutableService.test.ts
@@ -4,15 +4,19 @@ import { GetIplayerExecutableService } from 'src/service/getIplayerExecutableSer
 import historyService from 'src/service/historyService';
 import queueService from 'src/service/queueService';
 import socketService from 'src/service/socketService';
+import synonymService from 'src/service/synonymService';
 import { IplayarrParameter } from 'src/types/IplayarrParameters';
 import { IPlayerSearchResult, VideoType } from 'src/types/IPlayerSearchResult';
 import { Synonym } from 'src/types/Synonym';
 
 jest.mock('src/service/configService');
-jest.mock('src/service/queueService');
-jest.mock('src/service/socketService');
+const mockedConfigService = jest.mocked(configService);
 jest.mock('src/service/historyService');
 jest.mock('src/service/loggingService');
+jest.mock('src/service/queueService');
+jest.mock('src/service/socketService');
+jest.mock('src/service/synonymService');
+const mockedSynonymService = jest.mocked(synonymService);
 jest.mock('fs');
 jest.mock('path');
 
@@ -31,8 +35,9 @@ describe('GetIplayerExecutableService', () => {
             const mockExec = 'mock_exec';
             const mockArgs = ['arg1', 'arg2'];
 
-            (configService.getParameter as jest.Mock).mockImplementation((key: IplayarrParameter) => {
-                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return `${mockExec} ${mockArgs.join(' ')}`;
+            mockedConfigService.getParameter.mockImplementation((key: IplayarrParameter) => {
+                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return Promise.resolve(`${mockExec} ${mockArgs.join(' ')}`);
+                return Promise.resolve(undefined);
             });
 
             const result = await service.getIPlayerExec();
@@ -52,8 +57,9 @@ describe('GetIplayerExecutableService', () => {
             const mockExec = 'mock_exec';
             const mockArgs = ['arg1', 'arg2'];
 
-            (configService.getParameter as jest.Mock).mockImplementation((key: IplayarrParameter) => {
-                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return `${mockExec} ${mockArgs.join(' ')}`;
+            mockedConfigService.getParameter.mockImplementation((key: IplayarrParameter) => {
+                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return Promise.resolve(`${mockExec} ${mockArgs.join(' ')}`);
+                return Promise.resolve(undefined);
             });
 
             const result = await service.getIPlayerExec();
@@ -65,8 +71,9 @@ describe('GetIplayerExecutableService', () => {
         });
 
         it('should fallback to get_iplayer exec if GET_IPLAYER_EXEC is not set', async () => {
-            (configService.getParameter as jest.Mock).mockImplementation((key: IplayarrParameter) => {
-                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return undefined;
+            mockedConfigService.getParameter.mockImplementation((key: IplayarrParameter) => {
+                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return Promise.resolve(undefined);
+                return Promise.resolve(undefined);
             });
 
             const result = await service.getIPlayerExec();
@@ -82,10 +89,11 @@ describe('GetIplayerExecutableService', () => {
             const mockExec = 'mock_exec';
             const mockArgs = ['arg1', 'arg2'];
 
-            (configService.getParameter as jest.Mock).mockImplementation((key: IplayarrParameter) => {
-                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return `${mockExec} ${mockArgs.join(' ')}`;
-                if (key === IplayarrParameter.DOWNLOAD_DIR) return mockDownloadDir;
-                if (key === IplayarrParameter.ADDITIONAL_IPLAYER_DOWNLOAD_PARAMS) return 'extraParam';
+            mockedConfigService.getParameter.mockImplementation((key: IplayarrParameter) => {
+                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return Promise.resolve(`${mockExec} ${mockArgs.join(' ')}`);
+                if (key === IplayarrParameter.DOWNLOAD_DIR) return Promise.resolve(mockDownloadDir);
+                if (key === IplayarrParameter.ADDITIONAL_IPLAYER_DOWNLOAD_PARAMS) return Promise.resolve('extraParam');
+                return Promise.resolve(undefined);
             });
 
             const result = await service.getAllDownloadParameters(mockPid);
@@ -110,8 +118,9 @@ describe('GetIplayerExecutableService', () => {
             const mockExec = 'mock_exec';
             const mockArgs = ['arg1', 'arg2'];
 
-            (configService.getParameter as jest.Mock).mockImplementation((key: IplayarrParameter) => {
-                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return `${mockExec} ${mockArgs.join(' ')}`;
+            mockedConfigService.getParameter.mockImplementation((key: IplayarrParameter) => {
+                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return Promise.resolve(`${mockExec} ${mockArgs.join(' ')}`);
+                return Promise.resolve(undefined);
             });
 
             const result = await service.getSearchParameters(mockTerm, mockSynonym);
@@ -132,9 +141,10 @@ describe('GetIplayerExecutableService', () => {
             const mockExec = 'mock_exec';
             const mockArgs = ['arg1', 'arg2'];
 
-            (configService.getParameter as jest.Mock).mockImplementation((key: IplayarrParameter) => {
-                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return `${mockExec} ${mockArgs.join(' ')}`;
-                if (key === IplayarrParameter.RSS_FEED_HOURS) return mockRssHours;
+            mockedConfigService.getParameter.mockImplementation((key: IplayarrParameter) => {
+                if (key === IplayarrParameter.GET_IPLAYER_EXEC) return Promise.resolve(`${mockExec} ${mockArgs.join(' ')}`);
+                if (key === IplayarrParameter.RSS_FEED_HOURS) return Promise.resolve(mockRssHours);
+                return Promise.resolve(undefined);
             });
 
             const result = await service.getSearchParameters(mockTerm);
@@ -243,7 +253,41 @@ describe('GetIplayerExecutableService', () => {
     describe('processCompletedSearch', () => {
         it('should process results and create NZB name', async () => {
             const mockResults : IPlayerSearchResult[] = [{
-                pid: '12345', title: 'Test Title',
+                pid: '12345',
+                title: 'Test Title',
+                number: 0,
+                channel: 'BBC One',
+                request: {
+                    term : 'Term',
+                    line : 'line'
+                },
+                type: VideoType.TV
+            }];
+            const mockSynonym : Synonym = {
+                filenameOverride: 'test.nzb',
+                id: 'synonym-1',
+                from: 'Test Title',
+                target: 'To',
+                exemptions: ''
+            };
+
+            mockedConfigService.getParameter.mockImplementation((key: IplayarrParameter) => {
+                if (key === IplayarrParameter.VIDEO_QUALITY) return Promise.resolve('hd');
+                if (key === IplayarrParameter.TV_FILENAME_TEMPLATE) return Promise.resolve('TV-{{title}}-{{synonym}}-{{quality}}');
+                if (key === IplayarrParameter.MOVIE_FILENAME_TEMPLATE) return Promise.resolve('Movie-{{title}}-{{synonym}}-{{quality}}');
+                return Promise.resolve(undefined);
+            });
+
+            const results = await service.processCompletedSearch(mockResults, mockSynonym);
+
+            expect(results[0]).toHaveProperty('nzbName', 'TV-Test.Title-test.nzb-720p');
+            expect(mockedSynonymService.getSynonym).not.toHaveBeenCalled();
+        });
+
+        it('should look up synonym if not passed in', async () => {
+            const mockResults : IPlayerSearchResult[] = [{
+                pid: '12345',
+                title: 'Test Title',
                 number: 0,
                 channel: 'BBC One',
                 request: {
@@ -256,19 +300,23 @@ describe('GetIplayerExecutableService', () => {
                 filenameOverride: 'test.nzb',
                 id: 'synonym-1',
                 from: 'From',
-                target: 'To',
+                target: 'Test Title',
                 exemptions: ''
             };
 
-            (configService.getParameter as jest.Mock).mockImplementation((key: IplayarrParameter) => {
-                if (key === IplayarrParameter.VIDEO_QUALITY) return 'hd';
-                if (key === IplayarrParameter.TV_FILENAME_TEMPLATE) return 'TV-{{title}}-{{quality}}';
-                if (key === IplayarrParameter.MOVIE_FILENAME_TEMPLATE) return 'Movie-{{title}}-{{quality}}';
+            mockedConfigService.getParameter.mockImplementation((key: IplayarrParameter) => {
+                if (key === IplayarrParameter.VIDEO_QUALITY) return Promise.resolve('hd');
+                if (key === IplayarrParameter.TV_FILENAME_TEMPLATE) return Promise.resolve('TV-{{title}}-{{synonym}}-{{quality}}');
+                if (key === IplayarrParameter.MOVIE_FILENAME_TEMPLATE) return Promise.resolve('Movie-{{title}}-{{synonym}}-{{quality}}');
+                return Promise.resolve(undefined);
             });
 
-            const results = await service.processCompletedSearch(mockResults, mockSynonym);
+            mockedSynonymService.getSynonym.mockResolvedValue(mockSynonym);
 
-            expect(results[0]).toHaveProperty('nzbName', 'TV-Test.Title-720p');
+            const results = await service.processCompletedSearch(mockResults, undefined);
+
+            expect(results[0]).toHaveProperty('nzbName', 'TV-Test.Title-test.nzb-720p');
+            expect(synonymService.getSynonym).toHaveBeenCalledWith('Test Title');
         });
     });
 });


### PR DESCRIPTION
RSS results are not for a particular search term, so they never match a Synonym, meaning filename overrides don't get applied for results. This PR updates the filename creation to look up synonyms if we don't have one already. 

Closes #114.