### PR TITLE
Add safeguard for null program type

### DIFF
--- a/src/service/iplayerDetailsService.ts
+++ b/src/service/iplayerDetailsService.ts
@@ -61,7 +61,9 @@ class IPlayerDetailsService {
 
     async findBrandForPid(pid: string, checked: string[] = []): Promise<string | undefined> {
         const { programme }: IPlayerMetadataResponse = await this.getMetadata(pid);
-        if (programme?.type == 'brand') {
+        if (programme.type == null) return undefined;
+
+        if (programme.type == 'brand') {
             return programme.pid;
         } else if (programme.parent) {
             if (!checked.includes(programme.parent.programme.pid) && programme.parent.programme.pid != pid) {

--- a/src/service/iplayerDetailsService.ts
+++ b/src/service/iplayerDetailsService.ts
@@ -61,7 +61,7 @@ class IPlayerDetailsService {
 
     async findBrandForPid(pid: string, checked: string[] = []): Promise<string | undefined> {
         const { programme }: IPlayerMetadataResponse = await this.getMetadata(pid);
-        if (programme.type == 'brand') {
+        if (programme?.type == 'brand') {
             return programme.pid;
         } else if (programme.parent) {
             if (!checked.includes(programme.parent.programme.pid) && programme.parent.programme.pid != pid) {

--- a/src/service/iplayerDetailsService.ts
+++ b/src/service/iplayerDetailsService.ts
@@ -61,7 +61,7 @@ class IPlayerDetailsService {
 
     async findBrandForPid(pid: string, checked: string[] = []): Promise<string | undefined> {
         const { programme }: IPlayerMetadataResponse = await this.getMetadata(pid);
-        if (programme.type == null) return undefined;
+        if (programme == null) return undefined;
 
         if (programme.type == 'brand') {
             return programme.pid;


### PR DESCRIPTION
Hey, I ran into this error today:
```
Fetching schedule for CBeebies on 2025-06-16... https://www.bbc.co.uk/schedules/p00fzl9s/2025/06/16
/app/dist/src/service/iplayerDetailsService.js:53
        if (programme.type == 'brand') {
                      ^

TypeError: Cannot read properties of undefined (reading 'type')
    at IPlayerDetailsService.findBrandForPid (/app/dist/src/service/iplayerDetailsService.js:53:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async NativeSearchService.search (/app/dist/src/service/search/NativeSearchService.js:31:34)
    at async SearchFacade.search (/app/dist/src/facade/searchFacade.js:33:23)
    at async exports.default (/app/dist/src/endpoints/newznab/SearchEndpoint.js:15:19)
```

hopefully this pr fixes it! :3