### PR TITLE
Replace MD5 password hashing with bcrypt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@types/lunr": "^2.3.7",
                 "axios": "^1.8.2",
+                "bcrypt": "^6.0.0",
                 "connect-redis": "^8.0.3",
                 "cors": "^2.8.5",
                 "dotenv": "^16.4.7",
@@ -37,6 +38,7 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.22.0",
+                "@types/bcrypt": "^6.0.0",
                 "@types/cors": "^2.8.17",
                 "@types/express": "^5.0.0",
                 "@types/express-session": "^1.18.1",
@@ -1743,6 +1745,16 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/bcrypt": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+            "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/body-parser": {
             "version": "1.19.5",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -2983,6 +2995,20 @@
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
             "engines": {
                 "node": "^4.5.0 || >= 5.9"
+            }
+        },
+        "node_modules/bcrypt": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+            "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-addon-api": "^8.3.0",
+                "node-gyp-build": "^4.8.4"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/binary-extensions": {
@@ -7815,6 +7841,15 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "license": "MIT"
         },
+        "node_modules/node-addon-api": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+            "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18 || ^20 || >= 21"
+            }
+        },
         "node_modules/node-cron": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
@@ -7832,6 +7867,17 @@
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "bin": {
                 "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
             }
         },
         "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dependencies": {
         "@types/lunr": "^2.3.7",
         "axios": "^1.8.2",
+        "bcrypt": "^6.0.0",
         "connect-redis": "^8.0.3",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -51,6 +52,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.22.0",
+        "@types/bcrypt": "^6.0.0",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/express-session": "^1.18.1",

--- a/src/routes/AuthRoute.ts
+++ b/src/routes/AuthRoute.ts
@@ -9,7 +9,7 @@ import { redis } from '../service/redis/redisService';
 import { IplayarrParameter } from '../types/IplayarrParameters';
 import { ApiError, ApiResponse } from '../types/responses/ApiResponse';
 import User from '../types/User';
-import { md5 } from '../utils/Utils';
+import { comparePassword, hashPassword, isLegacyMD5Hash, md5 } from '../utils/Utils';
 
 declare module 'express-session' {
     interface SessionData {
@@ -81,13 +81,20 @@ router.get('/oidc/login', async (req: Request, res: Response) => {
 
 router.post('/oidc/test', async (req: Request, res: Response) => {
     const { OIDC_CONFIG_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_CALLBACK_HOST } = req.body;
-    const authUrl = await OIDCService.oidcConnection(req, OIDC_CONFIG_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_CALLBACK_HOST, 'test');
+    const authUrl = await OIDCService.oidcConnection(
+        req,
+        OIDC_CONFIG_URL,
+        OIDC_CLIENT_ID,
+        OIDC_CLIENT_SECRET,
+        OIDC_CALLBACK_HOST,
+        'test'
+    );
     res.redirect(authUrl);
 });
 
 router.get('/oidc/callback', async (req: Request, res: Response) => {
-    const allowedEmailsList = await configService.getParameter(IplayarrParameter.OIDC_ALLOWED_EMAILS) || '';
-    const allowedEmails = allowedEmailsList.split(',').map(email => email.trim().toLowerCase());
+    const allowedEmailsList = (await configService.getParameter(IplayarrParameter.OIDC_ALLOWED_EMAILS)) || '';
+    const allowedEmails = allowedEmailsList.split(',').map((email) => email.trim().toLowerCase());
     const code = req.query.code as string;
     const codeVerifier = req.session.codeVerifier;
 
@@ -99,12 +106,15 @@ router.get('/oidc/callback', async (req: Request, res: Response) => {
     const stateParam = req.query.state as string;
     const stateData = JSON.parse(Buffer.from(stateParam, 'base64url').toString());
     const isTest = stateData.mode === 'test';
-    const email: string | undefined = isTest ?
-        await OIDCService.getUserEmail(req, stateData.details.configUrl, stateData.details.clientId, stateData.details.clientSecret) :
-        await OIDCService.validateUser(req);
+    const email: string | undefined = isTest
+        ? await OIDCService.getUserEmail(
+              req,
+              stateData.details.configUrl,
+              stateData.details.clientId,
+              stateData.details.clientSecret
+          )
+        : await OIDCService.validateUser(req);
     const validUser = email && allowedEmails.includes(email.toLowerCase());
-
-
 
     if (isTest) {
         res.send(`
@@ -137,7 +147,6 @@ router.get('/oidc/callback', async (req: Request, res: Response) => {
     }
 });
 
-
 router.post('/login', async (req: Request, res: Response) => {
     const [AUTH_USERNAME, AUTH_PASSWORD] = await Promise.all([
         configService.getParameter(IplayarrParameter.AUTH_USERNAME),
@@ -145,7 +154,26 @@ router.post('/login', async (req: Request, res: Response) => {
     ]);
     const { username, password } = req.body;
 
-    if (username === AUTH_USERNAME && md5(password) === AUTH_PASSWORD) {
+    if (username !== AUTH_USERNAME || !AUTH_PASSWORD) {
+        res.status(401).json({ error: ApiError.INVALID_CREDENTIALS } as ApiResponse);
+        return;
+    }
+
+    let passwordValid = false;
+
+    if (isLegacyMD5Hash(AUTH_PASSWORD)) {
+        // Stored password is a legacy MD5 hash — compare with MD5, then migrate to bcrypt
+        passwordValid = md5(password) === AUTH_PASSWORD;
+        if (passwordValid) {
+            const bcryptHash = await hashPassword(password);
+            await configService.setParameter(IplayarrParameter.AUTH_PASSWORD, bcryptHash);
+        }
+    } else {
+        // Stored password is a bcrypt hash
+        passwordValid = await comparePassword(password, AUTH_PASSWORD);
+    }
+
+    if (passwordValid) {
         req.session.user = { username };
         res.json({ status: true });
         return;

--- a/src/routes/json-api/SettingsRoute.ts
+++ b/src/routes/json-api/SettingsRoute.ts
@@ -5,7 +5,7 @@ import configService, { ConfigMap } from '../../service/configService';
 import { IplayarrParameter } from '../../types/IplayarrParameters';
 import { qualityProfiles } from '../../types/QualityProfiles';
 import { ApiError, ApiResponse } from '../../types/responses/ApiResponse';
-import { md5 } from '../../utils/Utils';
+import { comparePassword, hashPassword, isLegacyMD5Hash, md5 } from '../../utils/Utils';
 import { ConfigFormValidator } from '../../validators/ConfigFormValidator';
 import { Validator } from '../../validators/Validator';
 
@@ -38,8 +38,21 @@ router.put('/', async (req: Request, res: Response) => {
         const val = req.body[key];
         if (key == IplayarrParameter.AUTH_PASSWORD) {
             const existing = await configService.getParameter(IplayarrParameter.AUTH_PASSWORD);
-            const hashed = md5(val);
-            if (existing != hashed && existing != val) {
+            // Check if the submitted value is already the stored hash (no change)
+            if (existing === val) {
+                continue;
+            }
+            // Check if the plaintext matches the existing hash (no change)
+            let alreadyMatches = false;
+            if (existing) {
+                if (isLegacyMD5Hash(existing)) {
+                    alreadyMatches = md5(val) === existing;
+                } else {
+                    alreadyMatches = await comparePassword(val, existing);
+                }
+            }
+            if (!alreadyMatches) {
+                const hashed = await hashPassword(val);
                 await configService.setParameter(key as IplayarrParameter, hashed);
             }
         } else {

--- a/src/service/configService.ts
+++ b/src/service/configService.ts
@@ -33,7 +33,7 @@ const configService = {
         ACTIVE_LIMIT: '3',
         REFRESH_SCHEDULE: '0 * * * *',
         AUTH_USERNAME: 'admin',
-        AUTH_PASSWORD: '5f4dcc3b5aa765d61d8327deb882cf99',
+        AUTH_PASSWORD: '$2b$10$4fiP4.TMyY3v08NQaQGPR.8HBbqXUlTNbQ11YWpTT9ptMCZFCRoeq',
         FALLBACK_FILENAME_SUFFIX: 'WEB.H264-BBC',
         MOVIE_FILENAME_TEMPLATE: '{{#if synonym}}{{synonym}}{{else}}{{title}}{{/if}}.WEBDL.{{quality}}-BBC',
         TV_FILENAME_TEMPLATE:
@@ -44,7 +44,7 @@ const configService = {
         ARCHIVE_ENABLED: 'false',
         DOWNLOAD_CLIENT: 'GET_IPLAYER',
         OUTPUT_FORMAT: 'mp4',
-        AUTH_TYPE: 'form'
+        AUTH_TYPE: 'form',
     } as ConfigMap,
 
     getParameter: async (parameter: IplayarrParameter): Promise<string | undefined> => {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,3 +1,4 @@
+import bcrypt from 'bcrypt';
 import * as crypto from 'crypto';
 import { Request } from 'express';
 import fs from 'fs';
@@ -49,9 +50,10 @@ export async function createNZBName(result: IPlayerSearchResult | IPlayerDetails
                     ? '00'
                     : undefined,
         episodeTitle: result.episodeTitle?.trim().replaceAll(removeUnsafeCharsRegex, ''),
-        synonym: synonym?.target.trim().toLowerCase() === title.toLowerCase()
-            ? (synonym.filenameOverride ?? synonym.from)?.trim().replaceAll(removeUnsafeCharsRegex, '')
-            : undefined,
+        synonym:
+            synonym?.target.trim().toLowerCase() === title.toLowerCase()
+                ? (synonym.filenameOverride ?? synonym.from)?.trim().replaceAll(removeUnsafeCharsRegex, '')
+                : undefined,
         quality: qualityProfile.quality,
     } as FilenameTemplateContext)
         .replaceAll(/[\s/]|[\s\\-_]{2,}/g, '.')
@@ -62,8 +64,24 @@ export function getBaseUrl(req: Request): string {
     return `${req.protocol}://${req.hostname}:${req.socket.localPort}`;
 }
 
+const BCRYPT_SALT_ROUNDS = 10;
+const MD5_HEX_REGEX = /^[a-f0-9]{32}$/;
+
+/** @deprecated Use hashPassword instead. Retained only for migrating legacy MD5 hashes. */
 export function md5(input: string): string {
     return crypto.createHash('md5').update(input).digest('hex');
+}
+
+export async function hashPassword(plaintext: string): Promise<string> {
+    return bcrypt.hash(plaintext, BCRYPT_SALT_ROUNDS);
+}
+
+export async function comparePassword(plaintext: string, hash: string): Promise<boolean> {
+    return bcrypt.compare(plaintext, hash);
+}
+
+export function isLegacyMD5Hash(value: string): boolean {
+    return MD5_HEX_REGEX.test(value);
 }
 
 export async function createNZBDownloadLink(
@@ -86,7 +104,7 @@ export async function createNZBDownloadLink(
 export async function getQualityProfile(): Promise<QualityProfile> {
     const videoQuality = (await configService.getParameter(IplayarrParameter.VIDEO_QUALITY)) as string;
     const profile = qualityProfiles.find(({ id }) => id == videoQuality) as QualityProfile;
-    return profile ? profile : qualityProfiles.find(({ quality }) => quality === 'hd') as QualityProfile;
+    return profile ? profile : (qualityProfiles.find(({ quality }) => quality === 'hd') as QualityProfile);
 }
 
 export function removeAllQueryParams(str: string): string {
@@ -142,8 +160,10 @@ export async function calculateSeasonAndEpisode(
     const estimatedSeries = nativeSeriesMatch
         ? getPotentialRoman(nativeSeriesMatch[1])
         : parent?.type == 'series'
-            ? parent.position ?? 0
-            : parent ? 0 : undefined;
+          ? (parent.position ?? 0)
+          : parent
+            ? 0
+            : undefined;
 
     // Check if this is a special episode
     const isSpecial =
@@ -153,8 +173,8 @@ export async function calculateSeasonAndEpisode(
     // Override series to 0 if counts indicate specials container
     let series =
         parent?.expected_child_count != null &&
-            (parent.aggregated_episode_count ?? 0) > parent.expected_child_count &&
-            isSpecial
+        (parent.aggregated_episode_count ?? 0) > parent.expected_child_count &&
+        isSpecial
             ? 0
             : estimatedSeries;
 
@@ -163,8 +183,10 @@ export async function calculateSeasonAndEpisode(
     let episode = episodeMatch
         ? parseInt(episodeMatch[1])
         : !isSpecial && (estimatedSeries ?? 0) > 0
-            ? programme.position ?? 0
-            : parent ? 0 : undefined;
+          ? (programme.position ?? 0)
+          : parent
+            ? 0
+            : undefined;
 
     // Determine episode title - use subtitle for specials in container series
     const episodeTitle =
@@ -223,7 +245,7 @@ export function getETA(eta: string | undefined, size: number, speed: number, per
         return '';
     }
 
-    const remainingSize = size * (1 - (percent / 100))
+    const remainingSize = size * (1 - percent / 100);
     const totalSeconds = remainingSize / speed;
     const hours = Math.floor(totalSeconds / 3600);
     const minutes = Math.floor((totalSeconds % 3600) / 60);

--- a/tests/facade/downloadFacade.test.ts
+++ b/tests/facade/downloadFacade.test.ts
@@ -7,138 +7,141 @@ import GetIplayerDownloadService from '../../src/service/download/GetIplayerDown
 import { DownloadClient } from '../../src/types/enums/DownloadClient';
 
 // Mocks
+jest.mock('bcrypt', () => ({
+    hash: jest.fn().mockResolvedValue('$2b$10$mockedhash'),
+    compare: jest.fn().mockResolvedValue(false),
+}));
+
 jest.mock('fs', () => ({
-  mkdirSync: jest.fn(),
-  writeFileSync: jest.fn(),
-  readdirSync: jest.fn(),
-  copyFileSync: jest.fn(),
-  rmSync: jest.fn(),
-  rm: jest.fn(),
-  stat: jest.fn(),
-  readdir: jest.fn()
+    mkdirSync: jest.fn(),
+    writeFileSync: jest.fn(),
+    readdirSync: jest.fn(),
+    copyFileSync: jest.fn(),
+    rmSync: jest.fn(),
+    rm: jest.fn(),
+    stat: jest.fn(),
+    readdir: jest.fn(),
 }));
 
 jest.mock('child_process', () => ({
-  spawn: jest.fn(),
+    spawn: jest.fn(),
 }));
 
 jest.mock('../../src/service/configService', () => ({
-  getParameter: jest.fn(),
+    getParameter: jest.fn(),
 }));
 
 jest.mock('../../src/service/download/GetIplayerDownloadService', () => ({
-  download: jest.fn(),
-  postProcess: jest.fn(),
+    download: jest.fn(),
+    postProcess: jest.fn(),
 }));
 
 jest.mock('../../src/service/download/YTDLPDownloadService', () => ({
-  download: jest.fn(),
-  postProcess: jest.fn(),
+    download: jest.fn(),
+    postProcess: jest.fn(),
 }));
 
 jest.mock('../../src/service/queueService', () => ({
-  updateQueue: jest.fn(),
-  getFromQueue: jest.fn(),
-  removeFromQueue: jest.fn(),
+    updateQueue: jest.fn(),
+    getFromQueue: jest.fn(),
+    removeFromQueue: jest.fn(),
 }));
 
 jest.mock('../../src/service/loggingService', () => ({
-  error: jest.fn(),
-  debug: jest.fn(),
-  log: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    log: jest.fn(),
 }));
 
 jest.mock('../../src/service/socketService', () => ({
-  emit: jest.fn(),
+    emit: jest.fn(),
 }));
 
 describe('DownloadFacade', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  describe('download', () => {
-    it('should correctly create directory, select service and handle process events', async () => {
-      const pid = 'test-pid';
-      const downloadDir = '/downloads';
-      const pidDir = '/downloads/test-pid';
-
-      // Mocks
-      (configService.getParameter as jest.Mock)
-        .mockResolvedValueOnce(downloadDir) // For DOWNLOAD_DIR
-        .mockResolvedValueOnce(DownloadClient.GET_IPLAYER); // For DOWNLOAD_CLIENT
-
-      const mockChildProcess = {
-        stdout: { on: jest.fn() },
-        stderr: { on: jest.fn() },
-        on: jest.fn(),
-      };
-
-      (GetIplayerDownloadService.download as jest.Mock).mockResolvedValue(mockChildProcess);
-
-      // Act
-      const result = await downloadFacade.download(pid);
-
-      // Asserts
-      expect(configService.getParameter).toHaveBeenCalledWith('DOWNLOAD_DIR');
-      expect(fs.mkdirSync).toHaveBeenCalledWith(pidDir, { recursive: true });
-      expect(fs.writeFileSync).toHaveBeenCalledWith(`${pidDir}/${timestampFile}`, '');
-
-      expect(configService.getParameter).toHaveBeenCalledWith('DOWNLOAD_CLIENT');
-      expect(GetIplayerDownloadService.download).toHaveBeenCalledWith(pid, pidDir);
-
-      expect(mockChildProcess.stderr.on).toHaveBeenCalledWith('data', expect.any(Function));
-      expect(mockChildProcess.stdout.on).toHaveBeenCalledWith('data', expect.any(Function));
-      expect(mockChildProcess.on).toHaveBeenCalledWith('close', expect.any(Function));
-
-      expect(result).toBe(mockChildProcess);
-    });
-  });
-
-  describe('cleanupFailedDownloads', () => {
-    it('should delete old download directories', async () => {
-      const downloadDir = '/downloads';
-      const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1000;
-
-      const mockDirEntry = {
-        name: 'oldDir',
-        isDirectory: () => true,
-      };
-
-      (configService.getParameter as jest.Mock).mockResolvedValue(downloadDir);
-      (fs.readdir as unknown as  jest.Mock).mockImplementation((_path, opts, cb) => cb(null, [mockDirEntry]));
-      (fs.stat as unknown as  jest.Mock).mockImplementation((_path, cb) =>
-        cb(null, { mtimeMs: threeHoursAgo - 10000 })
-      );
-      (fs.rm as unknown as  jest.Mock).mockImplementation((_path, opts, cb) => cb(null));
-
-      await downloadFacade.cleanupFailedDownloads();
-
-      expect(fs.rm).toHaveBeenCalledWith(
-        expect.stringContaining('oldDir'),
-        { recursive: true, force: true },
-        expect.any(Function)
-      );
+    beforeEach(() => {
+        jest.clearAllMocks();
     });
 
-    it('should not delete recent directories', async () => {
-      const downloadDir = '/downloads';
-      const now = Date.now();
+    describe('download', () => {
+        it('should correctly create directory, select service and handle process events', async () => {
+            const pid = 'test-pid';
+            const downloadDir = '/downloads';
+            const pidDir = '/downloads/test-pid';
 
-      const mockDirEntry = {
-        name: 'recentDir',
-        isDirectory: () => true,
-      };
+            // Mocks
+            (configService.getParameter as jest.Mock)
+                .mockResolvedValueOnce(downloadDir) // For DOWNLOAD_DIR
+                .mockResolvedValueOnce(DownloadClient.GET_IPLAYER); // For DOWNLOAD_CLIENT
 
-      (configService.getParameter as jest.Mock).mockResolvedValue(downloadDir);
-      (fs.readdir as unknown as jest.Mock).mockImplementation((_path, opts, cb) => cb(null, [mockDirEntry]));
-      (fs.stat as unknown as  jest.Mock).mockImplementation((_path, cb) =>
-        cb(null, { mtimeMs: now })
-      );
+            const mockChildProcess = {
+                stdout: { on: jest.fn() },
+                stderr: { on: jest.fn() },
+                on: jest.fn(),
+            };
 
-      await downloadFacade.cleanupFailedDownloads();
+            (GetIplayerDownloadService.download as jest.Mock).mockResolvedValue(mockChildProcess);
 
-      expect(fs.rm).not.toHaveBeenCalled();
+            // Act
+            const result = await downloadFacade.download(pid);
+
+            // Asserts
+            expect(configService.getParameter).toHaveBeenCalledWith('DOWNLOAD_DIR');
+            expect(fs.mkdirSync).toHaveBeenCalledWith(pidDir, { recursive: true });
+            expect(fs.writeFileSync).toHaveBeenCalledWith(`${pidDir}/${timestampFile}`, '');
+
+            expect(configService.getParameter).toHaveBeenCalledWith('DOWNLOAD_CLIENT');
+            expect(GetIplayerDownloadService.download).toHaveBeenCalledWith(pid, pidDir);
+
+            expect(mockChildProcess.stderr.on).toHaveBeenCalledWith('data', expect.any(Function));
+            expect(mockChildProcess.stdout.on).toHaveBeenCalledWith('data', expect.any(Function));
+            expect(mockChildProcess.on).toHaveBeenCalledWith('close', expect.any(Function));
+
+            expect(result).toBe(mockChildProcess);
+        });
     });
-  });
+
+    describe('cleanupFailedDownloads', () => {
+        it('should delete old download directories', async () => {
+            const downloadDir = '/downloads';
+            const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1000;
+
+            const mockDirEntry = {
+                name: 'oldDir',
+                isDirectory: () => true,
+            };
+
+            (configService.getParameter as jest.Mock).mockResolvedValue(downloadDir);
+            (fs.readdir as unknown as jest.Mock).mockImplementation((_path, opts, cb) => cb(null, [mockDirEntry]));
+            (fs.stat as unknown as jest.Mock).mockImplementation((_path, cb) =>
+                cb(null, { mtimeMs: threeHoursAgo - 10000 })
+            );
+            (fs.rm as unknown as jest.Mock).mockImplementation((_path, opts, cb) => cb(null));
+
+            await downloadFacade.cleanupFailedDownloads();
+
+            expect(fs.rm).toHaveBeenCalledWith(
+                expect.stringContaining('oldDir'),
+                { recursive: true, force: true },
+                expect.any(Function)
+            );
+        });
+
+        it('should not delete recent directories', async () => {
+            const downloadDir = '/downloads';
+            const now = Date.now();
+
+            const mockDirEntry = {
+                name: 'recentDir',
+                isDirectory: () => true,
+            };
+
+            (configService.getParameter as jest.Mock).mockResolvedValue(downloadDir);
+            (fs.readdir as unknown as jest.Mock).mockImplementation((_path, opts, cb) => cb(null, [mockDirEntry]));
+            (fs.stat as unknown as jest.Mock).mockImplementation((_path, cb) => cb(null, { mtimeMs: now }));
+
+            await downloadFacade.cleanupFailedDownloads();
+
+            expect(fs.rm).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/tests/routes/AuthRoute.test.ts
+++ b/tests/routes/AuthRoute.test.ts
@@ -6,18 +6,21 @@ import AuthRoute, { addAuthMiddleware } from '../../src/routes/AuthRoute';
 import configService from '../../src/service/configService';
 import { IplayarrParameter } from '../../src/types/IplayarrParameters';
 import { ApiError } from '../../src/types/responses/ApiResponse';
-import { md5 } from '../../src/utils/Utils';
 import * as Utils from '../../src/utils/Utils';
 
 jest.mock('../../src/service/configService');
-jest.spyOn(Utils, 'md5').mockReturnValue('hashed');
 jest.mock('uuid', () => ({ v4: () => 'mock-token' }));
-jest.mock('openid-client', () => { });
+jest.mock('openid-client', () => {});
+
+// Bcrypt hash of 'password' (pre-computed for deterministic tests)
+const BCRYPT_HASH_PASSWORD = '$2b$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy';
 
 describe('AuthRoute', () => {
     let app: express.Express;
 
     beforeEach(() => {
+        jest.restoreAllMocks();
+
         app = express();
         app.use(express.json());
 
@@ -35,11 +38,13 @@ describe('AuthRoute', () => {
     });
 
     describe('POST /login', () => {
-        it('should login successfully with correct credentials', async () => {
+        it('should login successfully with bcrypt-hashed password', async () => {
             (configService.getParameter as jest.Mock)
                 .mockResolvedValueOnce('admin') // AUTH_USERNAME
-                .mockResolvedValueOnce('hashed'); // AUTH_PASSWORD
-            (md5 as jest.Mock).mockReturnValue('hashed');
+                .mockResolvedValueOnce(BCRYPT_HASH_PASSWORD); // AUTH_PASSWORD
+
+            jest.spyOn(Utils, 'isLegacyMD5Hash').mockReturnValue(false);
+            jest.spyOn(Utils, 'comparePassword').mockResolvedValue(true);
 
             const res = await request(app).post('/login').send({
                 username: 'admin',
@@ -48,17 +53,76 @@ describe('AuthRoute', () => {
 
             expect(res.status).toBe(200);
             expect(res.body).toEqual({ status: true });
+            expect(Utils.comparePassword).toHaveBeenCalledWith('password', BCRYPT_HASH_PASSWORD);
         });
 
-        it('should fail login with incorrect credentials', async () => {
+        it('should login with legacy MD5 hash and migrate to bcrypt', async () => {
+            const legacyMD5 = '5f4dcc3b5aa765d61d8327deb882cf99';
+            (configService.getParameter as jest.Mock)
+                .mockResolvedValueOnce('admin') // AUTH_USERNAME
+                .mockResolvedValueOnce(legacyMD5); // AUTH_PASSWORD (MD5 of 'password')
+
+            jest.spyOn(Utils, 'isLegacyMD5Hash').mockReturnValue(true);
+            jest.spyOn(Utils, 'md5').mockReturnValue(legacyMD5);
+            jest.spyOn(Utils, 'hashPassword').mockResolvedValue(BCRYPT_HASH_PASSWORD);
+            (configService.setParameter as jest.Mock).mockResolvedValue(undefined);
+
+            const res = await request(app).post('/login').send({
+                username: 'admin',
+                password: 'password',
+            });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toEqual({ status: true });
+            // Should have migrated the password to bcrypt
+            expect(Utils.hashPassword).toHaveBeenCalledWith('password');
+            expect(configService.setParameter).toHaveBeenCalledWith(
+                IplayarrParameter.AUTH_PASSWORD,
+                BCRYPT_HASH_PASSWORD
+            );
+        });
+
+        it('should fail login with incorrect credentials (bcrypt)', async () => {
             (configService.getParameter as jest.Mock)
                 .mockResolvedValueOnce('admin')
-                .mockResolvedValueOnce('hashed');
-            (md5 as jest.Mock).mockReturnValue('wrong');
+                .mockResolvedValueOnce(BCRYPT_HASH_PASSWORD);
+
+            jest.spyOn(Utils, 'isLegacyMD5Hash').mockReturnValue(false);
+            jest.spyOn(Utils, 'comparePassword').mockResolvedValue(false);
 
             const res = await request(app).post('/login').send({
                 username: 'admin',
                 password: 'wrongpassword',
+            });
+
+            expect(res.status).toBe(401);
+            expect(res.body).toEqual({ error: ApiError.INVALID_CREDENTIALS });
+        });
+
+        it('should fail login with incorrect credentials (legacy MD5)', async () => {
+            const legacyMD5 = '5f4dcc3b5aa765d61d8327deb882cf99';
+            (configService.getParameter as jest.Mock).mockResolvedValueOnce('admin').mockResolvedValueOnce(legacyMD5);
+
+            jest.spyOn(Utils, 'isLegacyMD5Hash').mockReturnValue(true);
+            jest.spyOn(Utils, 'md5').mockReturnValue('different_hash');
+
+            const res = await request(app).post('/login').send({
+                username: 'admin',
+                password: 'wrongpassword',
+            });
+
+            expect(res.status).toBe(401);
+            expect(res.body).toEqual({ error: ApiError.INVALID_CREDENTIALS });
+        });
+
+        it('should fail login with wrong username', async () => {
+            (configService.getParameter as jest.Mock)
+                .mockResolvedValueOnce('admin')
+                .mockResolvedValueOnce(BCRYPT_HASH_PASSWORD);
+
+            const res = await request(app).post('/login').send({
+                username: 'wrong',
+                password: 'password',
             });
 
             expect(res.status).toBe(401);
@@ -85,8 +149,10 @@ describe('AuthRoute', () => {
 
             (configService.getParameter as jest.Mock)
                 .mockResolvedValueOnce('admin')
-                .mockResolvedValueOnce('hashed');
-            (md5 as jest.Mock).mockReturnValue('hashed');
+                .mockResolvedValueOnce(BCRYPT_HASH_PASSWORD);
+
+            jest.spyOn(Utils, 'isLegacyMD5Hash').mockReturnValue(false);
+            jest.spyOn(Utils, 'comparePassword').mockResolvedValue(true);
 
             await agent.post('/login').send({ username: 'admin', password: 'any' });
             const res = await agent.get('/me');
@@ -112,14 +178,17 @@ describe('AuthRoute', () => {
             (configService.setParameter as jest.Mock).mockResolvedValue(undefined);
             (configService.defaultConfigMap as any) = {
                 AUTH_USERNAME: 'admin',
-                AUTH_PASSWORD: 'hashed',
+                AUTH_PASSWORD: '5f4dcc3b5aa765d61d8327deb882cf99',
             };
 
             const res2 = await request(app).post('/resetPassword').send({ key: 'mock-token' });
             expect(res2.status).toBe(200);
             expect(res2.body).toEqual({ status: true });
             expect(configService.setParameter).toHaveBeenCalledWith(IplayarrParameter.AUTH_USERNAME, 'admin');
-            expect(configService.setParameter).toHaveBeenCalledWith(IplayarrParameter.AUTH_PASSWORD, 'hashed');
+            expect(configService.setParameter).toHaveBeenCalledWith(
+                IplayarrParameter.AUTH_PASSWORD,
+                '5f4dcc3b5aa765d61d8327deb882cf99'
+            );
         });
 
         it('should do nothing if token is invalid', async () => {

--- a/tests/routes/json-api/SettingsRoute.test.ts
+++ b/tests/routes/json-api/SettingsRoute.test.ts
@@ -5,6 +5,7 @@ import SettingsRoute from '../../../src/routes/json-api/SettingsRoute';
 import configService from '../../../src/service/configService';
 import { qualityProfiles } from '../../../src/types/QualityProfiles';
 import { ApiError, ApiResponse } from '../../../src/types/responses/ApiResponse';
+import * as Utils from '../../../src/utils/Utils';
 import { ConfigFormValidator } from '../../../src/validators/ConfigFormValidator';
 
 jest.mock('../../../src/service/configService');
@@ -25,6 +26,10 @@ describe('SettingsRoute', () => {
     const app = express();
     app.use(express.json());
     app.use('/', SettingsRoute);
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
 
     describe('GET /hiddenSettings', () => {
         beforeEach(() => {
@@ -87,10 +92,15 @@ describe('SettingsRoute', () => {
             expect(mockedConfigService.setParameter).not.toHaveBeenCalled();
         });
 
-        it('MD5 hashes AUTH_PASSWORD if included and different from existing value', async () => {
+        it('bcrypt hashes AUTH_PASSWORD if included and different from existing value', async () => {
+            const bcryptHash = '$2b$10$mockedbcrypthashvalue1234567890abcdefghijklmnop';
             mockedConfigFormValidator.validate.mockResolvedValue({});
             mockedConfigService.setParameter.mockResolvedValue();
-            mockedConfigService.getParameter.mockResolvedValueOnce('FUBAR');
+            mockedConfigService.getParameter.mockResolvedValueOnce('existing_hash');
+            jest.spyOn(Utils, 'isLegacyMD5Hash').mockReturnValue(false);
+            jest.spyOn(Utils, 'comparePassword').mockResolvedValue(false);
+            jest.spyOn(Utils, 'hashPassword').mockResolvedValue(bcryptHash);
+
             const body = { AUTH_PASSWORD: 'FOOBAR' };
             const response = await request(app).put('/').send(body);
             expect(response.statusCode).toBe(200);
@@ -99,17 +109,18 @@ describe('SettingsRoute', () => {
             expect(mockedConfigFormValidator.validate).toHaveBeenCalledWith(body);
             expect(mockedConfigService.getParameter).toHaveBeenCalledTimes(1);
             expect(mockedConfigService.getParameter).toHaveBeenCalledWith('AUTH_PASSWORD');
+            expect(Utils.hashPassword).toHaveBeenCalledWith('FOOBAR');
             expect(mockedConfigService.setParameter).toHaveBeenCalledTimes(1);
-            expect(mockedConfigService.setParameter).toHaveBeenCalledWith(
-                'AUTH_PASSWORD',
-                '95c72a49c488d59f60c022fcfecf4382'
-            );
+            expect(mockedConfigService.setParameter).toHaveBeenCalledWith('AUTH_PASSWORD', bcryptHash);
         });
 
-        it('does not update AUTH_PASSWORD if included and same as existing value', async () => {
+        it('does not update AUTH_PASSWORD if plaintext matches existing bcrypt hash', async () => {
             mockedConfigFormValidator.validate.mockResolvedValue({});
             mockedConfigService.setParameter.mockResolvedValue();
-            mockedConfigService.getParameter.mockResolvedValueOnce('95c72a49c488d59f60c022fcfecf4382');
+            mockedConfigService.getParameter.mockResolvedValueOnce('$2b$10$existinghash');
+            jest.spyOn(Utils, 'isLegacyMD5Hash').mockReturnValue(false);
+            jest.spyOn(Utils, 'comparePassword').mockResolvedValue(true);
+
             const body = { AUTH_PASSWORD: 'FOOBAR' };
             const response = await request(app).put('/').send(body);
             expect(response.statusCode).toBe(200);
@@ -118,6 +129,34 @@ describe('SettingsRoute', () => {
             expect(mockedConfigFormValidator.validate).toHaveBeenCalledWith(body);
             expect(mockedConfigService.getParameter).toHaveBeenCalledTimes(1);
             expect(mockedConfigService.getParameter).toHaveBeenCalledWith('AUTH_PASSWORD');
+            expect(mockedConfigService.setParameter).not.toHaveBeenCalled();
+        });
+
+        it('does not update AUTH_PASSWORD if plaintext matches existing legacy MD5 hash', async () => {
+            const legacyMD5 = '5f4dcc3b5aa765d61d8327deb882cf99';
+            mockedConfigFormValidator.validate.mockResolvedValue({});
+            mockedConfigService.setParameter.mockResolvedValue();
+            mockedConfigService.getParameter.mockResolvedValueOnce(legacyMD5);
+            jest.spyOn(Utils, 'isLegacyMD5Hash').mockReturnValue(true);
+            jest.spyOn(Utils, 'md5').mockReturnValue(legacyMD5);
+
+            const body = { AUTH_PASSWORD: 'password' };
+            const response = await request(app).put('/').send(body);
+            expect(response.statusCode).toBe(200);
+            expect(response.body).toEqual(body);
+            expect(mockedConfigService.setParameter).not.toHaveBeenCalled();
+        });
+
+        it('does not update AUTH_PASSWORD if submitted value is the stored hash itself', async () => {
+            const storedHash = '$2b$10$existinghash';
+            mockedConfigFormValidator.validate.mockResolvedValue({});
+            mockedConfigService.setParameter.mockResolvedValue();
+            mockedConfigService.getParameter.mockResolvedValueOnce(storedHash);
+
+            const body = { AUTH_PASSWORD: storedHash };
+            const response = await request(app).put('/').send(body);
+            expect(response.statusCode).toBe(200);
+            expect(response.body).toEqual(body);
             expect(mockedConfigService.setParameter).not.toHaveBeenCalled();
         });
     });

--- a/tests/service/getIplayerExecutableService.test.ts
+++ b/tests/service/getIplayerExecutableService.test.ts
@@ -11,6 +11,11 @@ import { IplayarrParameter } from '../../src/types/IplayarrParameters';
 import { IPlayerSearchResult, VideoType } from '../../src/types/IPlayerSearchResult';
 import { Synonym } from '../../src/types/Synonym';
 
+jest.mock('bcrypt', () => ({
+    hash: jest.fn().mockResolvedValue('$2b$10$mockedhash'),
+    compare: jest.fn().mockResolvedValue(false),
+}));
+
 jest.mock('../../src/service/configService');
 const mockedConfigService = jest.mocked(configService);
 jest.mock('../../src/service/historyService');

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,9 +1,5 @@
 jest.mock('dotenv');
 jest.mock('ioredis', () => jest.requireActual('ioredis-mock'));
-jest.mock('bcrypt', () => ({
-    hash: jest.fn().mockResolvedValue('$2b$10$mockedhash'),
-    compare: jest.fn().mockResolvedValue(false),
-}));
 
 beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,9 @@
 jest.mock('dotenv');
 jest.mock('ioredis', () => jest.requireActual('ioredis-mock'));
+jest.mock('bcrypt', () => ({
+    hash: jest.fn().mockResolvedValue('$2b$10$mockedhash'),
+    compare: jest.fn().mockResolvedValue(false),
+}));
 
 beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/utils/Utils.test.ts
+++ b/tests/utils/Utils.test.ts
@@ -1,3 +1,4 @@
+import bcrypt from 'bcrypt';
 import { Request } from 'express';
 
 import appService from '../../src/service/appService';
@@ -25,6 +26,8 @@ import p00bp2rm from '../data/p00bp2rm.json';
 import p0fq3s31 from '../data/p0fq3s31.json';
 import p09t2pyf from '../data/p09t2pyf.json';
 
+jest.mock('bcrypt');
+const mockedBcrypt = jest.mocked(bcrypt);
 
 jest.mock('../../src/service/configService');
 jest.mock('../../src/service/appService');
@@ -34,11 +37,49 @@ const mockedAppService = jest.mocked(appService);
 const mockedSkyhookService = jest.mocked(SkyhookService);
 
 describe('Utils', () => {
-    
-
-    describe('md5', () => {
+    describe('md5 (legacy)', () => {
         it('returns correct md5 hash', () => {
             expect(Utils.md5('hello')).toBe('5d41402abc4b2a76b9719d911017c592');
+        });
+    });
+
+    describe('hashPassword', () => {
+        it('delegates to bcrypt.hash with correct salt rounds', async () => {
+            mockedBcrypt.hash.mockResolvedValue('$2b$10$hashedvalue' as never);
+            const hash = await Utils.hashPassword('password');
+            expect(hash).toBe('$2b$10$hashedvalue');
+            expect(mockedBcrypt.hash).toHaveBeenCalledWith('password', 10);
+        });
+    });
+
+    describe('comparePassword', () => {
+        it('delegates to bcrypt.compare and returns result', async () => {
+            mockedBcrypt.compare.mockResolvedValue(true as never);
+            await expect(Utils.comparePassword('password', '$2b$10$hash')).resolves.toBe(true);
+            expect(mockedBcrypt.compare).toHaveBeenCalledWith('password', '$2b$10$hash');
+        });
+
+        it('returns false when bcrypt.compare returns false', async () => {
+            mockedBcrypt.compare.mockResolvedValue(false as never);
+            await expect(Utils.comparePassword('wrong', '$2b$10$hash')).resolves.toBe(false);
+        });
+    });
+
+    describe('isLegacyMD5Hash', () => {
+        it('returns true for a 32-char lowercase hex string', () => {
+            expect(Utils.isLegacyMD5Hash('5f4dcc3b5aa765d61d8327deb882cf99')).toBe(true);
+        });
+
+        it('returns false for a bcrypt hash', () => {
+            expect(Utils.isLegacyMD5Hash('$2b$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ01')).toBe(false);
+        });
+
+        it('returns false for an arbitrary string', () => {
+            expect(Utils.isLegacyMD5Hash('not-a-hash')).toBe(false);
+        });
+
+        it('returns false for uppercase hex', () => {
+            expect(Utils.isLegacyMD5Hash('5F4DCC3B5AA765D61D8327DEB882CF99')).toBe(false);
         });
     });
 
@@ -61,24 +102,25 @@ describe('Utils', () => {
             type: VideoType.MOVIE,
         } as IPlayerSearchResult;
 
-        const mockApp = (useSSL: boolean | string): App => ({
-            id: 'radarr-id',
-            name: 'Radarr',
-            type: AppType.RADARR,
-            url: 'http://radarr.example.com:7878',
-            iplayarr: {
-                host: 'iplayarr.example.com',
-                port: 443,
-                useSSL
-            }
-        }) as unknown as App;
+        const mockApp = (useSSL: boolean | string): App =>
+            ({
+                id: 'radarr-id',
+                name: 'Radarr',
+                type: AppType.RADARR,
+                url: 'http://radarr.example.com:7878',
+                iplayarr: {
+                    host: 'iplayarr.example.com',
+                    port: 443,
+                    useSSL,
+                },
+            }) as unknown as App;
 
         const req = {
             protocol: 'http',
             hostname: 'localhost',
             socket: {
-                localPort: 4404
-            }
+                localPort: 4404,
+            },
         } as unknown as Request;
 
         it('builds download link correctly without app', async () => {
@@ -153,154 +195,154 @@ describe('Utils', () => {
                 ).resolves.toBe('Thats.a.Title.S01E02.WEBDL.720p-BBC');
             });
 
-        it('synonym replaces title when title matches target', async () => {
-            await expect(
-                Utils.createNZBName(
-                    {
+            it('synonym replaces title when title matches target', async () => {
+                await expect(
+                    Utils.createNZBName(
+                        {
+                            title: synonym.target,
+                            pid: '',
+                            type: VideoType.TV,
+                            series: 1,
+                            episode: 2,
+                        },
+                        synonym
+                    )
+                ).resolves.toBe('Syno-Nym.Bus.S01E02.WEBDL.720p-BBC');
+            });
+
+            it('synonym does not replace title when title does not match target', async () => {
+                await expect(
+                    Utils.createNZBName(
+                        {
+                            title: 'Different Title',
+                            pid: '',
+                            type: VideoType.TV,
+                            series: 1,
+                            episode: 2,
+                        },
+                        synonym
+                    )
+                ).resolves.toBe('Different.Title.S01E02.WEBDL.720p-BBC');
+            });
+
+            it('synonym override replaces title when title matches target', async () => {
+                await expect(
+                    Utils.createNZBName(
+                        {
+                            title: synonym.target,
+                            pid: '',
+                            type: VideoType.TV,
+                            series: 1,
+                            episode: 2,
+                        },
+                        synonymWithOverride
+                    )
+                ).resolves.toBe('O.Ver_Ride.2.S01E02.WEBDL.720p-BBC');
+            });
+
+            it('synonym override does not replace title when title does not match target', async () => {
+                await expect(
+                    Utils.createNZBName(
+                        {
+                            title: 'Different Title',
+                            pid: '',
+                            type: VideoType.TV,
+                            series: 1,
+                            episode: 2,
+                        },
+                        synonymWithOverride
+                    )
+                ).resolves.toBe('Different.Title.S01E02.WEBDL.720p-BBC');
+            });
+
+            it('double digits', async () => {
+                await expect(
+                    Utils.createNZBName({
+                        title: synonym.target,
+                        pid: '',
+                        type: VideoType.TV,
+                        series: 12,
+                        episode: 34,
+                    })
+                ).resolves.toBe('Thats.a.Title.S12E34.WEBDL.720p-BBC');
+            });
+
+            it('yearly', async () => {
+                await expect(
+                    Utils.createNZBName({
+                        title: synonym.target,
+                        pid: '',
+                        type: VideoType.TV,
+                        series: 2025,
+                        episode: 365,
+                    })
+                ).resolves.toBe('Thats.a.Title.S2025E365.WEBDL.720p-BBC');
+            });
+
+            it('specials', async () => {
+                await expect(
+                    Utils.createNZBName({
+                        title: synonym.target,
+                        pid: '',
+                        type: VideoType.TV,
+                        series: 0,
+                        episode: 0,
+                    })
+                ).resolves.toBe('Thats.a.Title.S00E00.WEBDL.720p-BBC');
+            });
+
+            it('episode title', async () => {
+                await expect(
+                    Utils.createNZBName({
                         title: synonym.target,
                         pid: '',
                         type: VideoType.TV,
                         series: 1,
                         episode: 2,
-                    },
-                    synonym
-                )
-            ).resolves.toBe('Syno-Nym.Bus.S01E02.WEBDL.720p-BBC');
-        });
+                        episodeTitle: '14/04/2025: We Call That... an Episode.',
+                    })
+                ).resolves.toBe('Thats.a.Title.S01E02.14.04.2025.We.Call.That.an.Episode.WEBDL.720p-BBC');
+            });
 
-        it('synonym does not replace title when title does not match target', async () => {
-            await expect(
-                Utils.createNZBName(
-                    {
-                        title: 'Different Title',
-                        pid: '',
-                        type: VideoType.TV,
-                        series: 1,
-                        episode: 2,
-                    },
-                    synonym
-                )
-            ).resolves.toBe('Different.Title.S01E02.WEBDL.720p-BBC');
-        });
-
-        it('synonym override replaces title when title matches target', async () => {
-            await expect(
-                Utils.createNZBName(
-                    {
+            it('quality', async () => {
+                mockedConfigService.getParameter.mockImplementation((parameter: IplayarrParameter) =>
+                    Promise.resolve(
+                        parameter == IplayarrParameter.VIDEO_QUALITY ? 'fhd' : configService.defaultConfigMap[parameter]
+                    )
+                );
+                await expect(
+                    Utils.createNZBName({
                         title: synonym.target,
                         pid: '',
                         type: VideoType.TV,
                         series: 1,
                         episode: 2,
-                    },
-                    synonymWithOverride
-                )
-            ).resolves.toBe('O.Ver_Ride.2.S01E02.WEBDL.720p-BBC');
-        });
+                    })
+                ).resolves.toBe('Thats.a.Title.S01E02.WEBDL.1080p-BBC');
+            });
 
-        it('synonym override does not replace title when title does not match target', async () => {
-            await expect(
-                Utils.createNZBName(
-                    {
-                        title: 'Different Title',
+            it('missing series', async () => {
+                await expect(
+                    Utils.createNZBName({
+                        title: synonym.target,
+                        pid: '',
+                        type: VideoType.TV,
+                        episode: 2,
+                    })
+                ).resolves.toBe('Thats.a.Title.S00E00.WEBDL.720p-BBC');
+            });
+
+            it('missing episode', async () => {
+                await expect(
+                    Utils.createNZBName({
+                        title: synonym.target,
                         pid: '',
                         type: VideoType.TV,
                         series: 1,
-                        episode: 2,
-                    },
-                    synonymWithOverride
-                )
-            ).resolves.toBe('Different.Title.S01E02.WEBDL.720p-BBC');
+                    })
+                ).resolves.toBe('Thats.a.Title.S00E00.WEBDL.720p-BBC');
+            });
         });
-
-        it('double digits', async () => {
-            await expect(
-                Utils.createNZBName({
-                    title: synonym.target,
-                    pid: '',
-                    type: VideoType.TV,
-                    series: 12,
-                    episode: 34,
-                })
-            ).resolves.toBe('Thats.a.Title.S12E34.WEBDL.720p-BBC');
-        });
-
-        it('yearly', async () => {
-            await expect(
-                Utils.createNZBName({
-                    title: synonym.target,
-                    pid: '',
-                    type: VideoType.TV,
-                    series: 2025,
-                    episode: 365,
-                })
-            ).resolves.toBe('Thats.a.Title.S2025E365.WEBDL.720p-BBC');
-        });
-
-        it('specials', async () => {
-            await expect(
-                Utils.createNZBName({
-                    title: synonym.target,
-                    pid: '',
-                    type: VideoType.TV,
-                    series: 0,
-                    episode: 0,
-                })
-            ).resolves.toBe('Thats.a.Title.S00E00.WEBDL.720p-BBC');
-        });
-
-        it('episode title', async () => {
-            await expect(
-                Utils.createNZBName({
-                    title: synonym.target,
-                    pid: '',
-                    type: VideoType.TV,
-                    series: 1,
-                    episode: 2,
-                    episodeTitle: '14/04/2025: We Call That... an Episode.',
-                })
-            ).resolves.toBe('Thats.a.Title.S01E02.14.04.2025.We.Call.That.an.Episode.WEBDL.720p-BBC');
-        });
-
-        it('quality', async () => {
-            mockedConfigService.getParameter.mockImplementation((parameter: IplayarrParameter) =>
-                Promise.resolve(
-                    parameter == IplayarrParameter.VIDEO_QUALITY ? 'fhd' : configService.defaultConfigMap[parameter]
-                )
-            );
-            await expect(
-                Utils.createNZBName({
-                    title: synonym.target,
-                    pid: '',
-                    type: VideoType.TV,
-                    series: 1,
-                    episode: 2,
-                })
-            ).resolves.toBe('Thats.a.Title.S01E02.WEBDL.1080p-BBC');
-        });
-
-        it('missing series', async () => {
-            await expect(
-                Utils.createNZBName({
-                    title: synonym.target,
-                    pid: '',
-                    type: VideoType.TV,
-                    episode: 2,
-                })
-            ).resolves.toBe('Thats.a.Title.S00E00.WEBDL.720p-BBC');
-        });
-
-        it('missing episode', async () => {
-            await expect(
-                Utils.createNZBName({
-                    title: synonym.target,
-                    pid: '',
-                    type: VideoType.TV,
-                    series: 1,
-                })
-            ).resolves.toBe('Thats.a.Title.S00E00.WEBDL.720p-BBC');
-        });
-    });
 
         describe('MOVIE', () => {
             it('title only', async () => {
@@ -313,78 +355,78 @@ describe('Utils', () => {
                 ).resolves.toBe('Thats.a.Title.WEBDL.720p-BBC');
             });
 
-        it('synonym replaces title when title matches target', async () => {
-            await expect(
-                Utils.createNZBName(
-                    {
+            it('synonym replaces title when title matches target', async () => {
+                await expect(
+                    Utils.createNZBName(
+                        {
+                            title: synonym.target,
+                            pid: '',
+                            type: VideoType.MOVIE,
+                        },
+                        synonym
+                    )
+                ).resolves.toBe('Syno-Nym.Bus.WEBDL.720p-BBC');
+            });
+
+            it('synonym does not replace title when title does not match target', async () => {
+                await expect(
+                    Utils.createNZBName(
+                        {
+                            title: 'Different Title',
+                            pid: '',
+                            type: VideoType.MOVIE,
+                        },
+                        synonym
+                    )
+                ).resolves.toBe('Different.Title.WEBDL.720p-BBC');
+            });
+
+            it('synonym override replaces title when title matches target', async () => {
+                await expect(
+                    Utils.createNZBName(
+                        {
+                            title: synonym.target,
+                            pid: '',
+                            type: VideoType.MOVIE,
+                        },
+                        synonymWithOverride
+                    )
+                ).resolves.toBe('O.Ver_Ride.2.WEBDL.720p-BBC');
+            });
+
+            it('synonym override does not replace title when title does not match target', async () => {
+                await expect(
+                    Utils.createNZBName(
+                        {
+                            title: 'Different Title',
+                            pid: '',
+                            type: VideoType.MOVIE,
+                        },
+                        synonymWithOverride
+                    )
+                ).resolves.toBe('Different.Title.WEBDL.720p-BBC');
+            });
+
+            it('quality', async () => {
+                mockedConfigService.getParameter.mockImplementation((parameter: IplayarrParameter) =>
+                    Promise.resolve(
+                        parameter == IplayarrParameter.VIDEO_QUALITY ? 'fhd' : configService.defaultConfigMap[parameter]
+                    )
+                );
+                await expect(
+                    Utils.createNZBName({
                         title: synonym.target,
                         pid: '',
                         type: VideoType.MOVIE,
-                    },
-                    synonym
-                )
-            ).resolves.toBe('Syno-Nym.Bus.WEBDL.720p-BBC');
+                    })
+                ).resolves.toBe('Thats.a.Title.WEBDL.1080p-BBC');
+            });
         });
-
-        it('synonym does not replace title when title does not match target', async () => {
-            await expect(
-                Utils.createNZBName(
-                    {
-                        title: 'Different Title',
-                        pid: '',
-                        type: VideoType.MOVIE,
-                    },
-                    synonym
-                )
-            ).resolves.toBe('Different.Title.WEBDL.720p-BBC');
-        });
-
-        it('synonym override replaces title when title matches target', async () => {
-            await expect(
-                Utils.createNZBName(
-                    {
-                        title: synonym.target,
-                        pid: '',
-                        type: VideoType.MOVIE,
-                    },
-                    synonymWithOverride
-                )
-            ).resolves.toBe('O.Ver_Ride.2.WEBDL.720p-BBC');
-        });
-
-        it('synonym override does not replace title when title does not match target', async () => {
-            await expect(
-                Utils.createNZBName(
-                    {
-                        title: 'Different Title',
-                        pid: '',
-                        type: VideoType.MOVIE,
-                    },
-                    synonymWithOverride
-                )
-            ).resolves.toBe('Different.Title.WEBDL.720p-BBC');
-        });
-
-        it('quality', async () => {
-            mockedConfigService.getParameter.mockImplementation((parameter: IplayarrParameter) =>
-                Promise.resolve(
-                    parameter == IplayarrParameter.VIDEO_QUALITY ? 'fhd' : configService.defaultConfigMap[parameter]
-                )
-            );
-            await expect(
-                Utils.createNZBName({
-                    title: synonym.target,
-                    pid: '',
-                    type: VideoType.MOVIE,
-                })
-            ).resolves.toBe('Thats.a.Title.WEBDL.1080p-BBC');
-        });
-    });
 
         const synonym: Synonym = {
             id: '',
             from: 'Syno-Nym Bus?',
-            target: 'That\'s a Title!',
+            target: "That's a Title!",
             exemptions: '',
         };
 
@@ -426,22 +468,22 @@ describe('Utils', () => {
 
         it('extracts titles with special characters', () => {
             const [title, episode, series] = Utils.parseEpisodeDetailStrings(
-                'The Apprentice: You\'re Fired!: Series 19',
+                "The Apprentice: You're Fired!: Series 19",
                 '12',
                 '1'
             );
-            expect(title.trim()).toBe('The Apprentice: You\'re Fired!');
+            expect(title.trim()).toBe("The Apprentice: You're Fired!");
             expect(episode).toBe(12);
             expect(series).toBe(19);
         });
 
         it('fall back still extracts titles with special characters', () => {
             const [title, episode, series] = Utils.parseEpisodeDetailStrings(
-                'The Apprentice: You\'re Fired!',
+                "The Apprentice: You're Fired!",
                 '12',
                 '19'
             );
-            expect(title.trim()).toBe('The Apprentice: You\'re Fired!');
+            expect(title.trim()).toBe("The Apprentice: You're Fired!");
             expect(episode).toBe(12);
             expect(series).toBe(19);
         });
@@ -498,51 +540,97 @@ describe('Utils', () => {
 
     describe('calculateSeasonAndEpisode', () => {
         describe('episodes', () => {
-            it('standard series', async () => await assertSeasonAndEpisode(m0029c0g, VideoType.TV,
-                'Doctor Who', 3, 1, 'Episode 1'));
+            it('standard series', async () =>
+                await assertSeasonAndEpisode(m0029c0g, VideoType.TV, 'Doctor Who', 3, 1, 'Episode 1'));
 
-            it('season finale', async () => await assertSeasonAndEpisode(m00255nq, VideoType.TV,
-                'Return to Paradise', 1, 6, 'Oh Mine Papa'));
+            it('season finale', async () =>
+                await assertSeasonAndEpisode(m00255nq, VideoType.TV, 'Return to Paradise', 1, 6, 'Oh Mine Papa'));
 
-            it('yearly series', async () => await assertSeasonAndEpisode(m001zh50, VideoType.TV,
-                'Gardeners\' World', 2024, 1, 'Episode 1'));
+            it('yearly series', async () =>
+                await assertSeasonAndEpisode(m001zh50, VideoType.TV, "Gardeners' World", 2024, 1, 'Episode 1'));
 
-            it('parsed series title', async () => await assertSeasonAndEpisode(p09t2pyf, VideoType.TV,
-                'The Goes Wrong Show', 2, 1, 'Summer Once Again'));
+            it('parsed series title', async () =>
+                await assertSeasonAndEpisode(p09t2pyf, VideoType.TV, 'The Goes Wrong Show', 2, 1, 'Summer Once Again'));
 
-            it('parsed roman numerals series', async () => await assertSeasonAndEpisode(p00bp2rm, VideoType.TV,
-                'Red Dwarf', 4, 5, 'Dimension Jump'));
+            it('parsed roman numerals series', async () =>
+                await assertSeasonAndEpisode(p00bp2rm, VideoType.TV, 'Red Dwarf', 4, 5, 'Dimension Jump'));
 
-            it('no series data', async () => await assertSeasonAndEpisode(m002b3cb, VideoType.TV,
-                'BBC News', 0, 0, '13/04/2025', true));
+            it('no series data', async () =>
+                await assertSeasonAndEpisode(m002b3cb, VideoType.TV, 'BBC News', 0, 0, '13/04/2025', true));
 
             describe('specials', () => {
-                it('with no series', async () => await assertSeasonAndEpisode(m0026fkl, VideoType.TV,
-                    'Beyond Paradise', 0, 0, 'Christmas Special 2024', true));
+                it('with no series', async () =>
+                    await assertSeasonAndEpisode(
+                        m0026fkl,
+                        VideoType.TV,
+                        'Beyond Paradise',
+                        0,
+                        0,
+                        'Christmas Special 2024',
+                        true
+                    ));
 
-                it('only one in series', async () => await assertSeasonAndEpisode(p0fq3s31, VideoType.TV,
-                    'Red Dwarf', 13, 0, 'The Promised Land', true));
+                it('only one in series', async () =>
+                    await assertSeasonAndEpisode(
+                        p0fq3s31,
+                        VideoType.TV,
+                        'Red Dwarf',
+                        13,
+                        0,
+                        'The Promised Land',
+                        true
+                    ));
 
-                it('episode before series', async () => await assertSeasonAndEpisode(m001zh3r, VideoType.TV,
-                    'RHS Chelsea Flower Show', 2024, 0, 'RHS: Countdown to Chelsea', true));
+                it('episode before series', async () =>
+                    await assertSeasonAndEpisode(
+                        m001zh3r,
+                        VideoType.TV,
+                        'RHS Chelsea Flower Show',
+                        2024,
+                        0,
+                        'RHS: Countdown to Chelsea',
+                        true
+                    ));
 
-                it('episode within series', async () => await assertSeasonAndEpisode(m001zr9t, VideoType.TV,
-                    'RHS Chelsea Flower Show', 2024, 0, 'Highlights', true));
+                it('episode within series', async () =>
+                    await assertSeasonAndEpisode(
+                        m001zr9t,
+                        VideoType.TV,
+                        'RHS Chelsea Flower Show',
+                        2024,
+                        0,
+                        'Highlights',
+                        true
+                    ));
 
-                it('episode after series', async () => await assertSeasonAndEpisode(b0211hsl, VideoType.TV,
-                    'RHS Chelsea Flower Show', 0, 0, 'Red Button Special', true));
+                it('episode after series', async () =>
+                    await assertSeasonAndEpisode(
+                        b0211hsl,
+                        VideoType.TV,
+                        'RHS Chelsea Flower Show',
+                        0,
+                        0,
+                        'Red Button Special',
+                        true
+                    ));
 
-                it('from series of specials', async () => await assertSeasonAndEpisode(m000jbtq, VideoType.TV,
-                    'RHS Chelsea Flower Show', 0, 0, 'Making the Most of Your Time', true));
+                it('from series of specials', async () =>
+                    await assertSeasonAndEpisode(
+                        m000jbtq,
+                        VideoType.TV,
+                        'RHS Chelsea Flower Show',
+                        0,
+                        0,
+                        'Making the Most of Your Time',
+                        true
+                    ));
             });
         });
 
         describe('movies', () => {
-            it('standalone', async () =>
-                await assertSeasonAndEpisode(m001kscd, VideoType.MOVIE, 'Some Movie'));
+            it('standalone', async () => await assertSeasonAndEpisode(m001kscd, VideoType.MOVIE, 'Some Movie'));
 
-            it('sequel', async () =>
-                await assertSeasonAndEpisode(b008m7xk, VideoType.MOVIE, 'Another Movie'));
+            it('sequel', async () => await assertSeasonAndEpisode(b008m7xk, VideoType.MOVIE, 'Another Movie'));
         });
 
         describe('fallback to Skyhook', () => {


### PR DESCRIPTION
MD5 is cryptographically broken and can be reverse quickly by modern hardware. This swaps it out for bcrypt, which includes per-hash salting and is purpose-built for password storage.
Existing users don't need to do anything. On their next login, the old MD5 hash is verified normally, then silently replaced with a bcrypt hash behind the scenes. All subsequent logins use bcrypt.

### Changes:
- `src/utils/Utils.ts` — Added `hashPassword()`, `comparePassword()`, and `isLegacyMD5Hash()`. The old `md5()` is kept (marked deprecated) solely for the migration path.
- `src/routes/AuthRoute.ts` — Login now detects whether the stored hash is MD5 or bcrypt, verifies accordingly, and auto-migrates MD5 hashes to bcrypt on successful login.
- `src/routes/json-api/SettingsRoute.ts` — Password saves now use bcrypt. Duplicate detection handles both hash formats during the transition.
- Tests: Rewrote auth and settings password tests to cover both the bcrypt and legacy MD5 migration paths. Added a global bcrypt mock in test setup to avoid native binding conflicts with `fs` mocks.
- Dependencies: Added `bcrypt` and `@types/bcrypt`.

> Possibly in the future the MD5 can be completely removed but this would break login for users that aren't migrated