### PR TITLE
Fix useSSL string coercion causing SSL error when grabbing releases

### DIFF
--- a/frontend/src/components/common/form/SelectInput.vue
+++ b/frontend/src/components/common/form/SelectInput.vue
@@ -34,7 +34,7 @@ const props = defineProps({
         required: true,
     },
     modelValue: {
-        type: String,
+        type: [String, Boolean, Number],
         required: true,
     },
     error: {
@@ -54,7 +54,9 @@ const emit = defineEmits(['update:modelValue']);
 const localValue = ref(props.modelValue);
 
 watch(localValue, (newValue) => {
-    emit('update:modelValue', newValue);
+    // Find the original 'key' and use its value, preserving type
+    const option = props.options.find((o) => String(o.key) === String(newValue));
+    emit('update:modelValue', option ? option.key : newValue);
 });
 
 watch(

--- a/frontend/src/components/modals/AppForm.vue
+++ b/frontend/src/components/modals/AppForm.vue
@@ -78,8 +78,8 @@
                         name="iPlayarr Protocol"
                         :tooltip="`iPlayarr Protocol for connection from ${capitalize(form.type)}`"
                         :options="[
-                            { key: 'true', value: 'https' },
-                            { key: 'false', value: 'http' },
+                            { key: true, value: 'https' },
+                            { key: false, value: 'http' },
                         ]"
                     />
                     <TextInput
@@ -162,7 +162,7 @@ const emit = defineEmits(['saved']);
 const defaultForm = {
     download_client: {},
     iplayarr: {
-        useSSL: window.location.protocol == 'https:',
+        useSSL: false,
         host: window.location.hostname,
         port: window.location.port,
     },

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -76,7 +76,8 @@ export async function createNZBDownloadLink(
     if (app) {
         const appObj = await appService.getApp(app);
         if (appObj) {
-            baseUrl = `${appObj.iplayarr.useSSL ? 'https' : 'http'}://${appObj.iplayarr.host}:${appObj.iplayarr.port}`;
+            const useSSL = typeof appObj.iplayarr.useSSL === 'boolean' ? appObj.iplayarr.useSSL : appObj.iplayarr.useSSL === 'true';
+            baseUrl = `${useSSL ? 'https' : 'http'}://${appObj.iplayarr.host}:${appObj.iplayarr.port}`;
         }
     }
     return `${baseUrl}/api?mode=nzb-download&pid=${pid}&nzbName=${nzbName}&type=${type}&apikey=${apiKey}${app ? `&app=${app}` : ''}`;

--- a/tests/utils/Utils.test.ts
+++ b/tests/utils/Utils.test.ts
@@ -55,41 +55,63 @@ describe('Utils', () => {
     });
 
     describe('createNZBDownloadLink', () => {
-        it('builds download link correctly with and without app', async () => {
-            const base: IPlayerSearchResult = {
-                pid: '123',
-                nzbName: 'test.nzb',
-                type: VideoType.MOVIE,
-            } as IPlayerSearchResult;
+        const base: IPlayerSearchResult = {
+            pid: '123',
+            nzbName: 'test.nzb',
+            type: VideoType.MOVIE,
+        } as IPlayerSearchResult;
 
-            const req = {
-                protocol: 'http',
-                hostname: 'localhost',
-                socket: {
-                    localPort: 4404
-                }
-            } as unknown as Request
+        const mockApp = (useSSL: boolean | string): App => ({
+            id: 'radarr-id',
+            name: 'Radarr',
+            type: AppType.RADARR,
+            url: 'http://radarr.example.com:7878',
+            iplayarr: {
+                host: 'iplayarr.example.com',
+                port: 443,
+                useSSL
+            }
+        }) as unknown as App;
 
+        const req = {
+            protocol: 'http',
+            hostname: 'localhost',
+            socket: {
+                localPort: 4404
+            }
+        } as unknown as Request;
+
+        it('builds download link correctly without app', async () => {
             await expect(Utils.createNZBDownloadLink(req, base, 'apikey')).resolves.toBe(
                 'http://localhost:4404/api?mode=nzb-download&pid=123&nzbName=test.nzb&type=MOVIE&apikey=apikey'
             );
+        });
 
-            // Mock appService.getApp to return an app
-            const mockApp: App = {
-                id: 'radarr-id',
-                name: 'Radarr',
-                type: AppType.RADARR,
-                url: 'http://radarr.example.com:7878',
-                iplayarr: {
-                    host: 'iplayarr.example.com',
-                    port: 443,
-                    useSSL: true
-                }
-            } as App;
-            mockedAppService.getApp.mockResolvedValue(mockApp);
-
+        it('builds https download link when useSSL is boolean true', async () => {
+            mockedAppService.getApp.mockResolvedValue(mockApp(true));
             await expect(Utils.createNZBDownloadLink(req, base, 'apikey', 'radarr')).resolves.toBe(
                 'https://iplayarr.example.com:443/api?mode=nzb-download&pid=123&nzbName=test.nzb&type=MOVIE&apikey=apikey&app=radarr'
+            );
+        });
+
+        it('builds https download link when useSSL is string "true"', async () => {
+            mockedAppService.getApp.mockResolvedValue(mockApp('true'));
+            await expect(Utils.createNZBDownloadLink(req, base, 'apikey', 'radarr')).resolves.toBe(
+                'https://iplayarr.example.com:443/api?mode=nzb-download&pid=123&nzbName=test.nzb&type=MOVIE&apikey=apikey&app=radarr'
+            );
+        });
+
+        it('builds http download link when useSSL is boolean false', async () => {
+            mockedAppService.getApp.mockResolvedValue(mockApp(false));
+            await expect(Utils.createNZBDownloadLink(req, base, 'apikey', 'radarr')).resolves.toBe(
+                'http://iplayarr.example.com:443/api?mode=nzb-download&pid=123&nzbName=test.nzb&type=MOVIE&apikey=apikey&app=radarr'
+            );
+        });
+
+        it('builds http download link when useSSL is string "false"', async () => {
+            mockedAppService.getApp.mockResolvedValue(mockApp('false'));
+            await expect(Utils.createNZBDownloadLink(req, base, 'apikey', 'radarr')).resolves.toBe(
+                'http://iplayarr.example.com:443/api?mode=nzb-download&pid=123&nzbName=test.nzb&type=MOVIE&apikey=apikey&app=radarr'
             );
         });
     });


### PR DESCRIPTION
The `SelectInput` component coerces values to strings on interaction, so `useSSL` was stored as `"false"` rather than `false`. The string `"false"` is truthy, causing download links to use `https://` even with SSL disabled.

Fixed `SelectInput` to preserve option key types and added type coercion in `createNZBDownloadLink` to handle existing string values (so no need for users to update their config).

Closes #185.