### PR TITLE
Fix native search container expansion

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,70 +1,77 @@
-name: Publish Fork to GHCR
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker image
 
 on:
-  # This makes it run automatically when you push to your custom branch
-  push:
-    branches:
-      - 'fix/native-search-series-expansion'
-  # This gives you a "Run workflow" button in the GitHub UI to trigger it manually
-  workflow_dispatch:
+    release:
+        types: [published]
+    workflow_dispatch:
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to GHCR
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-      attestations: write
-      id-token: write
+    push_to_registry:
+        name: Push Docker image to Docker Hub
+        runs-on: ubuntu-latest
+        permissions:
+            packages: write
+            contents: read
+            attestations: write
+            id-token: write
 
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Log in to Docker Hub
+              uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+              with:
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/iplayarr
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+              with:
+                  images: nikorag/iplayarr
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Write version to JSON
-        # Uses the branch name or commit SHA for the version file instead of crashing on missing tags
-        run: |
-          echo "{\"version\": \"${{ github.ref_name }}\"}" > src/config/version.json
+            - name: Extract Git tag
+              id: extract_tag
+              run: echo "git_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          # Your Synology DS918+ uses linux/amd64
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/iplayarr:fork-native-search
-            ghcr.io/${{ github.repository_owner }}/iplayarr:${{ github.ref_name }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            iplayarr_version=${{ github.ref_name }}
+            - name: Write version to JSON
+              run: |
+                  echo "{\"version\": \"${{ env.git_tag }}\"}" > src/config/version.json
 
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ghcr.io/${{ github.repository_owner }}/iplayarr
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+            - name: Build and push Docker image
+              id: push
+              uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+              with:
+                  context: .
+                  file: ./Dockerfile
+                  push: true
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  tags: |
+                      ${{ steps.meta.outputs.tags }}
+                      nikorag/iplayarr:latest
+                  labels: ${{ steps.meta.outputs.labels }}
+                  build-args: |
+                      iplayarr_version=${{ env.git_tag }}
+
+            - name: Generate artifact attestation
+              uses: actions/attest-build-provenance@v2
+              with:
+                  subject-name: index.docker.io/nikorag/iplayarr
+                  subject-digest: ${{ steps.push.outputs.digest }}
+                  push-to-registry: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,77 +1,70 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# GitHub recommends pinning actions to a commit SHA.
-# To get a newer version, you will need to update the SHA.
-# You can also reference a tag or branch, but the action may change without warning.
-
-name: Publish Docker image
+name: Publish Fork to GHCR
 
 on:
-    release:
-        types: [published]
-    workflow_dispatch:
+  # This makes it run automatically when you push to your custom branch
+  push:
+    branches:
+      - 'fix/native-search-series-expansion'
+  # This gives you a "Run workflow" button in the GitHub UI to trigger it manually
+  workflow_dispatch:
 
 jobs:
-    push_to_registry:
-        name: Push Docker image to Docker Hub
-        runs-on: ubuntu-latest
-        permissions:
-            packages: write
-            contents: read
-            attestations: write
-            id-token: write
+  push_to_registry:
+    name: Push Docker image to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
 
-        steps:
-            - name: Check out the repo
-              uses: actions/checkout@v4
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
-            - name: Log in to Docker Hub
-              uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
-              with:
-                  username: ${{ secrets.DOCKER_USERNAME }}
-                  password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Extract metadata (tags, labels) for Docker
-              id: meta
-              uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-              with:
-                  images: nikorag/iplayarr
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/iplayarr
 
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-            - name: Extract Git tag
-              id: extract_tag
-              run: echo "git_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: Write version to JSON
+        # Uses the branch name or commit SHA for the version file instead of crashing on missing tags
+        run: |
+          echo "{\"version\": \"${{ github.ref_name }}\"}" > src/config/version.json
 
-            - name: Write version to JSON
-              run: |
-                  echo "{\"version\": \"${{ env.git_tag }}\"}" > src/config/version.json
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          # Your Synology DS918+ uses linux/amd64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/iplayarr:fork-native-search
+            ghcr.io/${{ github.repository_owner }}/iplayarr:${{ github.ref_name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            iplayarr_version=${{ github.ref_name }}
 
-            - name: Build and push Docker image
-              id: push
-              uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-              with:
-                  context: .
-                  file: ./Dockerfile
-                  push: true
-                  platforms: linux/amd64,linux/arm64,linux/arm/v7
-                  tags: |
-                      ${{ steps.meta.outputs.tags }}
-                      nikorag/iplayarr:latest
-                  labels: ${{ steps.meta.outputs.labels }}
-                  build-args: |
-                      iplayarr_version=${{ env.git_tag }}
-
-            - name: Generate artifact attestation
-              uses: actions/attest-build-provenance@v2
-              with:
-                  subject-name: index.docker.io/nikorag/iplayarr
-                  subject-digest: ${{ steps.push.outputs.digest }}
-                  push-to-registry: true
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/iplayarr
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/src/service/search/NativeSearchService.ts
+++ b/src/service/search/NativeSearchService.ts
@@ -26,36 +26,41 @@ class NativeSearchService implements AbstractSearchService {
 
             const lunrResults: Index.Result[] = this.#indexAndReSearch(term, results);
             const pidLedger: string[] = [];
+            const infoPidLedger: Set<string> = new Set();
 
             let infos: IPlayerDetails[] = [];
 
             for (const { ref } of lunrResults) {
                 const brandPid = await iplayerDetailsService.findBrandForPid(ref);
-                if (brandPid) {
-                    if (!pidLedger.includes(brandPid)) {
-                        const seriesList: IPlayerEpisodeMetadata[] = await iplayerDetailsService.getSeriesEpisodes(brandPid);
+                const searchHitMetadata = await iplayerDetailsService.getMetadata(ref);
+                const fallbackContainerPid = searchHitMetadata.programme.type == 'series' || searchHitMetadata.programme.type == 'brand'
+                    ? ref
+                    : undefined;
+                const containerPid = brandPid ?? fallbackContainerPid;
 
-                        // Add episodes from series containers
-                        const episodes = (await Promise.all(
-                            seriesList.filter(({ type }) => type == 'series').map(({ id }) => iplayerDetailsService.getSeriesEpisodes(id))
-                        )).flat();
-                        // Also include direct episode children (e.g., Christmas specials under the brand)
-                        episodes.push(...seriesList.filter(({ type, release_date_time }) => type == 'episode' && release_date_time != null));
-
+                if (containerPid) {
+                    if (!pidLedger.includes(containerPid)) {
+                        const episodes = await this.#expandEpisodesFromContainer(containerPid);
                         const chunks = splitArrayIntoChunks(episodes, 5);
-
-                        const chunkInfos: IPlayerDetails[] = [];
                         for (const chunk of chunks) {
                             const results: IPlayerDetails[] = await iplayerDetailsService.detailsForEpisodeMetadata(chunk);
-                            chunkInfos.push(...results);
+                            for (const info of results) {
+                                if (!infoPidLedger.has(info.pid)) {
+                                    infos.push(info);
+                                    infoPidLedger.add(info.pid);
+                                }
+                            }
                         }
-
-                        infos = [...infos, ...chunkInfos];
-                        pidLedger.push(brandPid);
+                        pidLedger.push(containerPid);
                     }
                 } else {
                     const pidInfos = await iplayerDetailsService.details([ref]);
-                    pidInfos.forEach(info => infos.push(info));
+                    for (const info of pidInfos) {
+                        if (!infoPidLedger.has(info.pid)) {
+                            infos.push(info);
+                            infoPidLedger.add(info.pid);
+                        }
+                    }
                 }
 
                 //Limit to only 150 results
@@ -70,6 +75,24 @@ class NativeSearchService implements AbstractSearchService {
         } else {
             return [];
         }
+    }
+
+    async #expandEpisodesFromContainer(containerPid: string): Promise<IPlayerEpisodeMetadata[]> {
+        const containerChildren: IPlayerEpisodeMetadata[] = await iplayerDetailsService.getSeriesEpisodes(containerPid);
+        const directEpisodes = containerChildren.filter(({ type, release_date_time }) => type == 'episode' && release_date_time != null);
+        const childContainers = containerChildren.filter(({ type }) => type == 'series' || type == 'brand');
+
+        const nestedChildren = (await Promise.all(
+            childContainers.map(({ id }) => iplayerDetailsService.getSeriesEpisodes(id))
+        )).flat();
+        const nestedEpisodes = nestedChildren.filter(({ type, release_date_time }) => type == 'episode' && release_date_time != null);
+
+        const combined = [...directEpisodes, ...nestedEpisodes];
+        const dedupedByPid = new Map<string, IPlayerEpisodeMetadata>();
+        for (const episode of combined) {
+            dedupedByPid.set(episode.id, episode);
+        }
+        return [...dedupedByPid.values()];
     }
 
     async processCompletedSearch(results: IPlayerSearchResult[], _inputTerm: string, synonym?: Synonym): Promise<IPlayerSearchResult[]> {

--- a/tests/service/search/NativeSearchService.test.ts
+++ b/tests/service/search/NativeSearchService.test.ts
@@ -21,15 +21,25 @@ describe('NativeSearchService', () => {
     let mockSynonym: any;
     let mockSizeFactor: number;
     let mockTerm: string;
+    const mockEpisodeDetails = (pid: string, title: string, runtime = 30) => ({
+        title,
+        pid,
+        type: 'episode',
+        firstBroadcast: '2025-01-01',
+        runtime,
+    });
 
     beforeEach(() => {
-        jest.clearAllMocks();
+        jest.resetAllMocks();
         mockSynonym = { synonymKey: 'synonymValue' };
         mockTerm = 'Test Term';
         mockSizeFactor = 1;
 
         (getQualityProfile as jest.Mock).mockResolvedValue({ sizeFactor: mockSizeFactor });
         (createNZBName as jest.Mock).mockResolvedValue('testNZBName');
+        (iplayerDetailsService.getMetadata as jest.Mock).mockResolvedValue({
+            programme: { type: 'episode' },
+        });
     });
 
     describe('search', () => {
@@ -239,6 +249,67 @@ describe('NativeSearchService', () => {
 
             expect(results.length).toBeGreaterThan(searchResultLimit); // First brand exceeds limit
             expect(iplayerDetailsService.getSeriesEpisodes).toHaveBeenCalledTimes(1); // Should not process second brand
+        });
+
+        it('should expand episodes when search hit is a series/brand container even if brand PID lookup fails', async () => {
+            (axios.get as jest.Mock).mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    new_search: { results: [{ id: 'containerPid1', title: mockTerm }] },
+                },
+            });
+
+            (iplayerDetailsService.findBrandForPid as jest.Mock).mockResolvedValue(null);
+            (iplayerDetailsService.getMetadata as jest.Mock).mockResolvedValue({
+                programme: { type: 'series' },
+            });
+
+            (iplayerDetailsService.getSeriesEpisodes as jest.Mock).mockResolvedValue([
+                { type: 'episode', id: 'ep1', title: 'Episode 1', release_date_time: '2025-01-01' },
+            ]);
+            (iplayerDetailsService.detailsForEpisodeMetadata as jest.Mock).mockResolvedValue([
+                mockEpisodeDetails('ep1', 'Episode 1'),
+            ]);
+
+            const results = await NativeSearchService.search(mockTerm);
+
+            expect(iplayerDetailsService.getSeriesEpisodes).toHaveBeenCalledWith('containerPid1');
+            expect(results).toHaveLength(1);
+            expect(results[0].pid).toBe('ep1');
+        });
+
+        it('should include nested container episodes and dedupe by PID', async () => {
+            (axios.get as jest.Mock).mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    new_search: { results: [{ id: 'containerPid1', title: mockTerm }] },
+                },
+            });
+
+            (iplayerDetailsService.findBrandForPid as jest.Mock).mockResolvedValue('containerPid1');
+
+            (iplayerDetailsService.getSeriesEpisodes as jest.Mock)
+                .mockResolvedValueOnce([
+                    { type: 'episode', id: 'ep1', title: 'Episode 1', release_date_time: '2025-01-01' },
+                    { type: 'brand', id: 'childBrand1', title: 'Child Brand' },
+                    { type: 'episode', id: 'noDate', title: 'No Date Episode' },
+                ])
+                .mockResolvedValueOnce([
+                    { type: 'episode', id: 'ep1', title: 'Episode 1 Duplicate', release_date_time: '2025-01-01' },
+                    { type: 'episode', id: 'ep2', title: 'Episode 2', release_date_time: '2025-01-02' },
+                ]);
+
+            (iplayerDetailsService.detailsForEpisodeMetadata as jest.Mock).mockResolvedValue([
+                mockEpisodeDetails('ep1', 'Episode 1'),
+                mockEpisodeDetails('ep2', 'Episode 2'),
+            ]);
+
+            const results = await NativeSearchService.search(mockTerm);
+
+            expect(iplayerDetailsService.getSeriesEpisodes).toHaveBeenCalledTimes(2);
+            expect(iplayerDetailsService.getSeriesEpisodes).toHaveBeenNthCalledWith(1, 'containerPid1');
+            expect(iplayerDetailsService.getSeriesEpisodes).toHaveBeenNthCalledWith(2, 'childBrand1');
+            expect(results.map((r) => r.pid).sort()).toEqual(['ep1', 'ep2']);
         });
     });
 


### PR DESCRIPTION
## Summary
- expand native-search results when the search hit resolves to a series or brand container PID, not only when brand resolution succeeds
- include direct and nested episode expansion for container hits, then dedupe by PID to avoid duplicate releases
- preserve existing behavior for standard brand expansion and one-off PID fallback while improving episode-level results for edge-case shows

## Verification
- local verification script against this patch returns episode-level results for `Smiley's People` (S0E1..S0E6)
- `The Mrs Merton Show` still returns expanded episode results under native search
- TypeScript backend compiles successfully (`npm run build:backend`)

## Context
This addresses cases where native search returns container-level matches but fails to expand to episode-level items needed by Sonarr.
