### PR TITLE
fix: add missing speed/size/sizeleft/kbpersec fields to SABnzbd queue response

### DIFF
--- a/src/endpoints/sabnzbd/QueueEndpoint.ts
+++ b/src/endpoints/sabnzbd/QueueEndpoint.ts
@@ -15,6 +15,7 @@ import {
     SabNZBQueueEntry,
 } from '../../types/responses/sabnzbd/QueueResponse';
 import { TrueFalseResponse } from '../../types/responses/sabnzbd/TrueFalseResponse';
+import { formatBytes } from '../../utils/formatters';
 import { AbstractSabNZBDActionEndpoint, ActionQueryString } from './AbstractSabNZBDActionEndpoint';
 
 
@@ -35,12 +36,21 @@ const actionDirectory: EndpointDirectory = {
         const queue: QueueEntry[] = queueService.getQueue();
         const downloadQueue: QueueEntry[] = queue.filter(({ status }) => status == QueueEntryStatus.DOWNLOADING);
         const iplayerComplete = await historyService.getHistory();
+
+        const totalMb = queue.reduce((acc, slot) => acc + (slot.details?.size || 0), 0);
+        const totalMbLeft = queue.reduce((acc, slot) => acc + (slot.details?.sizeLeft || 0), 0);
+        const totalSpeedKbs = downloadQueue.reduce((acc, slot) => acc + (slot.details?.speed || 0), 0);
+
         const queueResponse: SabNZBDQueueResponse = {
             ...queueSkeleton,
             status: downloadQueue.length > 0 ? QueueStatus.DOWNLOADING : QueueStatus.IDLE,
             noofslots_total: queue.length,
             noofslots: queue.length,
             finish: iplayerComplete.length,
+            speed: `${formatBytes(totalSpeedKbs * 1024)}/s`,
+            size: formatBytes(totalMb * 1024 * 1024),
+            sizeleft: formatBytes(totalMbLeft * 1024 * 1024),
+            kbpersec: totalSpeedKbs.toFixed(2),
             slots: queue.map(convertEntries),
         } as SabNZBDQueueResponse;
         res.json({ queue: queueResponse });

--- a/src/types/responses/sabnzbd/QueueResponse.ts
+++ b/src/types/responses/sabnzbd/QueueResponse.ts
@@ -37,6 +37,10 @@ export interface SabNZBDQueueResponse {
     noofslots_total: number;
     noofslots: number;
     finish: number;
+    speed: string;
+    size: string;
+    sizeleft: string;
+    kbpersec: string;
     slots: SabNZBQueueEntry[];
 }
 

--- a/tests/endpoints/sabnzbd/QueueEndpoint.test.ts
+++ b/tests/endpoints/sabnzbd/QueueEndpoint.test.ts
@@ -95,6 +95,10 @@ describe('AbstractSabNZBDActionEndpoint', () => {
                     'noofslots_total': 1,
                     'noofslots': 1,
                     'finish': 2,
+                    'speed': '0 Bytes/s',
+                    'size': '500 MB',
+                    'sizeleft': '100 MB',
+                    'kbpersec': '0.00',
                     'slots': [
                         {
                             'password': '',
@@ -164,6 +168,10 @@ describe('AbstractSabNZBDActionEndpoint', () => {
                     'noofslots_total': 1,
                     'noofslots': 1,
                     'finish': 0,
+                    'speed': '0 Bytes/s',
+                    'size': '700 MB',
+                    'sizeleft': '700 MB',
+                    'kbpersec': '0.00',
                     'slots': [
                         {
                             'password': '',


### PR DESCRIPTION
## Summary

Fixes #224

The `/api?mode=queue` response was missing fields required by SABnzbd-compatible clients, causing the [Homepage](https://gethomepage.dev) SABnzbd widget to crash with:

```
TypeError: Cannot read properties of undefined (reading 'split')
```

Homepage's widget calls `.split()` on `queue.speed` to parse the speed string — since iPlayarr wasn't returning it, it was `undefined`.

**Fields added to queue response:**

| Field | Example value | Description |
|---|---|---|
| `speed` | `"1.2 MB/s"` | Current download speed, formatted string |
| `size` | `"7.23 GB"` | Total queue size, formatted string |
| `sizeleft` | `"500 MB"` | Remaining queue size, formatted string |
| `kbpersec` | `"1234.56"` | Current speed in KB/s as string |

Speed is summed across all actively downloading slots. Size fields are summed across all queue slots.

## Test plan

- [x] Existing queue endpoint tests updated and passing
- [ ] Homepage SABnzbd widget renders without error when pointed at iPlayarr

🤖 Generated with [Claude Code](https://claude.com/claude-code)