### PR TITLE
fix: SABnzbd queue.speed format for Homepage rate widget

### DIFF
--- a/src/endpoints/sabnzbd/QueueEndpoint.ts
+++ b/src/endpoints/sabnzbd/QueueEndpoint.ts
@@ -15,7 +15,7 @@ import {
     SabNZBQueueEntry,
 } from '../../types/responses/sabnzbd/QueueResponse';
 import { TrueFalseResponse } from '../../types/responses/sabnzbd/TrueFalseResponse';
-import { formatBytes } from '../../utils/formatters';
+import { formatBytes, formatSabnzbdSpeedKbps } from '../../utils/formatters';
 import { AbstractSabNZBDActionEndpoint, ActionQueryString } from './AbstractSabNZBDActionEndpoint';
 
 
@@ -47,7 +47,7 @@ const actionDirectory: EndpointDirectory = {
             noofslots_total: queue.length,
             noofslots: queue.length,
             finish: iplayerComplete.length,
-            speed: `${formatBytes(totalSpeedKbs * 1024)}/s`,
+            speed: formatSabnzbdSpeedKbps(totalSpeedKbs),
             size: formatBytes(totalMb * 1024 * 1024),
             sizeleft: formatBytes(totalMbLeft * 1024 * 1024),
             kbpersec: totalSpeedKbs.toFixed(2),

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -7,3 +7,22 @@ export function formatBytes(bytes: number, unit: boolean = true, decimals: numbe
 
     return parseFloat((bytes / Math.pow(k, i)).toFixed(decimals)) + (unit ? ' ' + sizes[i] : '');
 }
+
+/**
+ * SABnzbd `queue.speed` format (e.g. "1.3 M", "500.0 K") for API compatibility.
+ * Tools like Homepage parse this as `<number> <single-letter>` (K/M/G/T/P tiers of KB/s).
+ * @param kbPerSec total speed in kilobytes per second
+ */
+export function formatSabnzbdSpeedKbps(kbPerSec: number): string {
+    if (!kbPerSec || kbPerSec <= 0) {
+        return '0 ';
+    }
+    const units = ['K', 'M', 'G', 'T', 'P'] as const;
+    let n = kbPerSec;
+    let i = 0;
+    while (n >= 1024 && i < units.length - 1) {
+        n /= 1024;
+        i += 1;
+    }
+    return `${n.toFixed(1)} ${units[i]}`;
+}

--- a/tests/endpoints/sabnzbd/QueueEndpoint.test.ts
+++ b/tests/endpoints/sabnzbd/QueueEndpoint.test.ts
@@ -58,6 +58,7 @@ describe('AbstractSabNZBDActionEndpoint', () => {
                         sizeLeft: 100,
                         eta: '00:05:00',
                         progress: 80.5,
+                        speed: 1296.02,
                     },
                 },
             ];
@@ -95,10 +96,10 @@ describe('AbstractSabNZBDActionEndpoint', () => {
                     'noofslots_total': 1,
                     'noofslots': 1,
                     'finish': 2,
-                    'speed': '0 Bytes/s',
+                    'speed': '1.3 M',
                     'size': '500 MB',
                     'sizeleft': '100 MB',
-                    'kbpersec': '0.00',
+                    'kbpersec': '1296.02',
                     'slots': [
                         {
                             'password': '',
@@ -168,7 +169,7 @@ describe('AbstractSabNZBDActionEndpoint', () => {
                     'noofslots_total': 1,
                     'noofslots': 1,
                     'finish': 0,
-                    'speed': '0 Bytes/s',
+                    'speed': '0 ',
                     'size': '700 MB',
                     'sizeleft': '700 MB',
                     'kbpersec': '0.00',

--- a/tests/utils/formatters.test.ts
+++ b/tests/utils/formatters.test.ts
@@ -6,6 +6,13 @@ describe('formatSabnzbdSpeedKbps', () => {
         expect(formatSabnzbdSpeedKbps(-1)).toBe('0 ');
     });
 
+    it('idle trailing space is load-bearing — Homepage fromUnits() splits on space to find unit', () => {
+        const idle = formatSabnzbdSpeedKbps(0);
+        const [value, unit] = idle.split(' ');
+        expect(value).toBe('0');
+        expect(unit).toBe('');  // empty unit, not undefined — the space must be present
+    });
+
     it('formats KB/s tier', () => {
         expect(formatSabnzbdSpeedKbps(50)).toBe('50.0 K');
     });

--- a/tests/utils/formatters.test.ts
+++ b/tests/utils/formatters.test.ts
@@ -1,4 +1,19 @@
-import { formatBytes } from '../../src/utils/formatters';
+import { formatBytes, formatSabnzbdSpeedKbps } from '../../src/utils/formatters';
+
+describe('formatSabnzbdSpeedKbps', () => {
+    it('returns SABnzbd-style zero when idle', () => {
+        expect(formatSabnzbdSpeedKbps(0)).toBe('0 ');
+        expect(formatSabnzbdSpeedKbps(-1)).toBe('0 ');
+    });
+
+    it('formats KB/s tier', () => {
+        expect(formatSabnzbdSpeedKbps(50)).toBe('50.0 K');
+    });
+
+    it('formats MB/s tier like SABnzbd / Homepage examples', () => {
+        expect(formatSabnzbdSpeedKbps(1296.02)).toBe('1.3 M');
+    });
+});
 
 describe('formatBytes', () => {
     it('formats bytes correctly', () => {


### PR DESCRIPTION
## Summary

Format `queue.speed` like **real SABnzbd** (`"1.3 M"`, `"0 "`, …) instead of `formatBytes(...) + "/s"` (`"1.2 MB/s"`), so clients that parse the short form (notably **Homepage**’s SABnzbd widget) show a non-zero **rate** when downloading.

## How we know this is correct

1. **SABnzbd contract** — Official API docs show JSON such as `"speed": "1.3 M"` next to `"kbpersec": "1296.02"`. That defines the intended string shape for `queue.speed`.  
   https://sabnzbd.org/wiki/configuration/5.0/api  

2. **Homepage parser** — `fromUnits()` splits `queue.speed` on a space and treats the second token as a **single letter** in `B|K|M|G|T|P`. Any other token (e.g. `MB/s`) makes `indexOf` fail and the rate becomes **0**.  
   https://github.com/gethomepage/homepage/blob/dev/src/widgets/sabnzbd/component.jsx  

3. **Homepage tests (behaviour spec)** — Their widget test passes `speed: "1.0 M"` and asserts the derived rate; that codifies the same contract as SABnzbd’s examples.  
   https://github.com/gethomepage/homepage/blob/dev/src/widgets/sabnzbd/component.test.jsx  

4. **Before / after** — iPlayarr used `formatBytes(totalSpeedKbs * 1024) + "/s"` → strings like `"500.00 KB/s"`, which **do not** match that parser. `formatSabnzbdSpeedKbps()` emits the short tier form so `fromUnits` matches SABnzbd + Homepage.

5. **Tests** — Unit tests for `formatSabnzbdSpeedKbps` (including `1296.02` → `"1.3 M"`) and updated `QueueEndpoint` expectations; full `npm test` (373 tests) passes.

## Related

- Homepage widget docs: https://gethomepage.dev/widgets/services/sabnzbd/  
- Earlier queue-field work (crash fix, not rate): PR **#225** / issue **#224**.
