### PR TITLE
fix: janitor skips directories for active queue entries

### DIFF
--- a/src/facade/downloadFacade.ts
+++ b/src/facade/downloadFacade.ts
@@ -60,8 +60,6 @@ class DownloadFacade {
                     //Move the resultant file
                     loggingService.debug(pid, `Looking for video files in ${directory}`);
                     const files = fs.readdirSync(directory);
-                    // Exclude _original files — these are get-iplayer's ffmpeg post-processing
-                    // backups and are deleted by get-iplayer after processing completes.
                     const videoFile = files.find((file) => (file.endsWith('.mp4') || file.endsWith('.mkv')) && !file.includes('_original'));
 
                     if (videoFile) {
@@ -146,8 +144,6 @@ class DownloadFacade {
             entries.forEach((entry) => {
                 if (!entry.isDirectory()) return;
 
-                // Never delete a directory for an actively-queued PID — the download
-                // process is still running and would get an ENOENT on its copy step.
                 if (queueService.getFromQueue(entry.name)) return;
 
                 const dirPath: string = path.join(downloadDir, entry.name);

--- a/src/facade/downloadFacade.ts
+++ b/src/facade/downloadFacade.ts
@@ -60,7 +60,7 @@ class DownloadFacade {
                     //Move the resultant file
                     loggingService.debug(pid, `Looking for video files in ${directory}`);
                     const files = fs.readdirSync(directory);
-                    const videoFile = files.find((file) => (file.endsWith('.mp4') || file.endsWith('.mkv')) && !file.includes('_original'));
+                    const videoFile = files.find((file) => (file.endsWith('.mp4') || file.endsWith('.mkv')) && !file.endsWith('_original.mp4') && !file.endsWith('_original.mkv'));
 
                     if (videoFile) {
                         const oldPath = path.join(directory, videoFile);

--- a/src/facade/downloadFacade.ts
+++ b/src/facade/downloadFacade.ts
@@ -60,7 +60,9 @@ class DownloadFacade {
                     //Move the resultant file
                     loggingService.debug(pid, `Looking for video files in ${directory}`);
                     const files = fs.readdirSync(directory);
-                    const videoFile = files.find((file) => file.endsWith('.mp4') || file.endsWith('.mkv'));
+                    // Exclude _original files — these are get-iplayer's ffmpeg post-processing
+                    // backups and are deleted by get-iplayer after processing completes.
+                    const videoFile = files.find((file) => (file.endsWith('.mp4') || file.endsWith('.mkv')) && !file.includes('_original'));
 
                     if (videoFile) {
                         const oldPath = path.join(directory, videoFile);
@@ -143,6 +145,10 @@ class DownloadFacade {
 
             entries.forEach((entry) => {
                 if (!entry.isDirectory()) return;
+
+                // Never delete a directory for an actively-queued PID — the download
+                // process is still running and would get an ENOENT on its copy step.
+                if (queueService.getFromQueue(entry.name)) return;
 
                 const dirPath: string = path.join(downloadDir, entry.name);
                 const filePath: string = path.join(dirPath, timestampFile);


### PR DESCRIPTION
Fixes #233.

`cleanupFailedDownloads` uses only timestamp age to decide what to delete. Downloads longer than 3 hours get their `incomplete/<pid>/` directory removed while the download process is still running. When the process exits, `#processComplete` races with the in-flight async `fs.rm`: `readdirSync` sees the files, `fs.rm` finishes and removes them, then `copyWithFallback` throws ENOENT. Because `historyService.addHistory` is never called, the arr client re-grabs the same episode on every RSS cycle.

Two changes to `downloadFacade.ts`:

- Janitor checks `queueService.getFromQueue(entry.name)` before touching a directory. The directory name is the PID, so this is a direct lookup. Active downloads are never pruned.
- `_original` files are excluded from the video file scan. These are get-iplayer's ffmpeg post-processing backups — deleted before get-iplayer exits, so they should never be the copy target.