### PR TITLE
fix: don't report false completion to Sonarr/Radarr when get-iplayer produces no file

### DIFF
--- a/src/endpoints/sabnzbd/HistoryEndpoint.ts
+++ b/src/endpoints/sabnzbd/HistoryEndpoint.ts
@@ -6,6 +6,7 @@ import historyService from '../../service/historyService';
 import { IplayarrParameter } from '../../types/IplayarrParameters';
 import { QueueEntry } from '../../types/QueueEntry';
 import {
+    HistoryStatus,
     historyEntrySkeleton,
     historySkeleton,
     SABNZBDHistoryEntryResponse,
@@ -51,6 +52,7 @@ const actionDirectory: EndpointDirectory = {
 };
 
 function createHistoryEntry(completeDir: string, item: QueueEntry, outputFormat: string): SABNZBDHistoryEntryResponse {
+    const failed = item.status == QueueEntryStatus.FAILED;
     return {
         ...historyEntrySkeleton,
         duplicate_key: item.pid,
@@ -64,6 +66,8 @@ function createHistoryEntry(completeDir: string, item: QueueEntry, outputFormat:
         name: `${item.nzbName}.${outputFormat}`,
         url: `${item.nzbName}.nzb`,
         bytes: (item.details?.size as number) * sizeFactor,
+        status: failed ? HistoryStatus.FAILED : HistoryStatus.COMPLETED,
+        fail_message: failed ? 'get-iplayer exited successfully but produced no video file' : '',
     } as SABNZBDHistoryEntryResponse;
 }
 

--- a/src/facade/downloadFacade.ts
+++ b/src/facade/downloadFacade.ts
@@ -16,6 +16,7 @@ import { DownloadClient } from '../types/enums/DownloadClient';
 import { IplayarrParameter } from '../types/IplayarrParameters';
 import { LogLine, LogLineLevel } from '../types/LogLine';
 import { QueueEntry } from '../types/QueueEntry';
+import { QueueEntryStatus } from '../types/responses/sabnzbd/QueueResponse';
 import { convertToMB, copyWithFallback, getETA } from '../utils/Utils';
 
 class DownloadFacade {
@@ -69,13 +70,26 @@ class DownloadFacade {
                         loggingService.debug(pid, `Moving ${oldPath} to ${newPath}`);
 
                         copyWithFallback(oldPath, newPath);
+                    } else {
+                        // get-iplayer exited 0 but produced no video file — this happens
+                        // silently (e.g. BBC schedule/API errors during the run). Reporting
+                        // success here means Sonarr/Radarr get a false completion signal and
+                        // then loop forever failing to import a file that was never created.
+                        loggingService.error(
+                            pid,
+                            `No video file found in ${directory} after download exited 0 for '${queueItem.nzbName}' — reporting failure instead of a false completion`
+                        );
                     }
 
                     // Delete the uuid directory and file after moving it
                     loggingService.debug(pid, `Deleting old directory ${directory}`);
                     fs.rmSync(directory, { recursive: true, force: true });
 
-                    await historyService.addHistory(queueItem);
+                    if (videoFile) {
+                        await historyService.addHistory(queueItem);
+                    } else {
+                        await historyService.addArchive(queueItem, QueueEntryStatus.FAILED);
+                    }
                 } catch (err) {
                     loggingService.error(err);
                 }

--- a/src/types/responses/sabnzbd/HistoryResponse.ts
+++ b/src/types/responses/sabnzbd/HistoryResponse.ts
@@ -1,5 +1,6 @@
 export enum HistoryStatus {
     COMPLETED = 'Completed',
+    FAILED = 'Failed',
 }
 
 export const historySkeleton: Partial<SabNZBDHistoryResponse> = {

--- a/src/types/responses/sabnzbd/QueueResponse.ts
+++ b/src/types/responses/sabnzbd/QueueResponse.ts
@@ -10,6 +10,7 @@ export enum QueueEntryStatus {
     QUEUED = 'Queued',
     FORWARDED = 'Forwarded',
     COMPLETE = 'Complete',
+    FAILED = 'Failed',
     CANCELLED = 'Cancelled',
     REMOVED = 'Removed'
 }


### PR DESCRIPTION
Fixes #234

get-iplayer can exit 0 without producing a video file. `#processComplete` only guards the file move with `if (videoFile)`. Directory cleanup and the completion signal to Sonarr/Radarr run afterward regardless, and `historyService.addHistory` always records status `COMPLETE`.

`HistoryStatus` had no `FAILED` value, so even a correctly tracked failure had no way to reach the SABnzbd-compatible response Sonarr/Radarr read. `createHistoryEntry` set `status: HistoryStatus.COMPLETED` for every entry through the skeleton default.

This PR:

- Calls `historyService.addHistory` (status `COMPLETE`) only when a video file was actually found and moved.
- Calls `historyService.addArchive(queueItem, QueueEntryStatus.FAILED)` and logs the failure when no file was produced.
- Adds `FAILED` to `QueueEntryStatus` and `HistoryStatus`.
- Makes `createHistoryEntry` serialize the item's real status, with a `fail_message`, instead of hardcoding `Completed`.

Sonarr/Radarr can now see a genuine `Failed` entry and react the normal way: blocklist and re-search, instead of retrying a phantom completion forever.

`npm run build:backend` (tsc) passes clean. I built and deployed this to my own instance. I haven't reproduced the exact silent get-iplayer failure to exercise the new failure path end to end, so that's still open. Happy to add a unit test around the no-videoFile branch of `processComplete` if that helps.