### PR TITLE
fix: don't crash the process when the BBC search API returns non-2xx

### DIFF
--- a/src/service/search/NativeSearchService.ts
+++ b/src/service/search/NativeSearchService.ts
@@ -18,7 +18,18 @@ class NativeSearchService implements AbstractSearchService {
     async search(term: string, synonym?: Synonym): Promise<IPlayerSearchResult[]> {
         const { sizeFactor } = await getQualityProfile();
         const url = `https://ibl.api.bbc.co.uk/ibl/v1/new-search?q=${encodeURIComponent(term)}`;
-        const response: AxiosResponse<IPlayerNewSearchResponse> = await axios.get(url);
+        let response: AxiosResponse<IPlayerNewSearchResponse>;
+        try {
+            response = await axios.get(url);
+        } catch (err) {
+            // axios rejects (doesn't resolve with a non-200 status) on 4xx/5xx by default.
+            // A single bad query — an odd synonym, an unexpected character — must not take
+            // down the whole process; every other in-flight search on this instance would
+            // die with it, and the Newznab endpoint would drop its response mid-stream from
+            // Sonarr/Radarr's point of view. Log and degrade to zero results instead.
+            loggingService.error(`NativeSearchService: BBC search failed for term '${term}': ${err}`);
+            return [];
+        }
         if (response.status == 200) {
             const {
                 new_search: { results },

--- a/src/service/search/NativeSearchService.ts
+++ b/src/service/search/NativeSearchService.ts
@@ -20,7 +20,7 @@ class NativeSearchService implements AbstractSearchService {
         const url = `https://ibl.api.bbc.co.uk/ibl/v1/new-search?q=${encodeURIComponent(term)}`;
         let response: AxiosResponse<IPlayerNewSearchResponse>;
         try {
-            response = await axios.get(url);
+            response = await axios.get(url, { timeout: 10000 });
         } catch (err) {
             // axios rejects (doesn't resolve with a non-200 status) on 4xx/5xx by default.
             // A single bad query — an odd synonym, an unexpected character — must not take


### PR DESCRIPTION
Fixes #236

`NativeSearchService#search` calls `axios.get()` against `ibl.api.bbc.co.uk/ibl/v1/new-search` with no error handling. axios rejects (doesn't resolve with a non-200 status) on 4xx/5xx, so any query BBC's backend doesn't like throws an unhandled promise rejection and takes down the entire process. The `if (response.status == 200) { ... } else { return []; }` branch further down is dead code, since a failing request never reaches it.

Observed in the wild: a synonym-translated search term triggered a 400 from BBC's backend during routine Sonarr indexer polling. The process died mid-request, Sonarr saw the connection drop, and the container restarted a couple seconds later — but every other in-flight search on that instance died with it.

This PR wraps the `axios.get()` call in try/catch, logs the failure, and returns `[]`, matching what the existing status-check branch already intended for a failed search.

`npm run build:backend` (tsc) passes clean. Built and deployed to my own instance; verified the container no longer restarts on the exact request that previously crashed it (`HTTP 200` now, uptime unaffected). I wasn't able to force the original 400-from-BBC condition on demand to see the new catch path fire directly, so flagging that as something worth exercising more thoroughly — happy to add a unit test mocking a rejected axios call if useful.