### PR TITLE
fix(security): require authenticated session for Socket.io connections

### DIFF
--- a/src/routes/AuthRoute.ts
+++ b/src/routes/AuthRoute.ts
@@ -30,21 +30,22 @@ const router: Router = Router();
 let token: string = '';
 let resetTimer: NodeJS.Timeout | undefined;
 
-export const addAuthMiddleware = (app: Express) => {
-    const sessionCookieSettings: any = { secure: false, maxAge: 1000 * 60 * 60 * 24 };
-    if (isDebug) {
-        sessionCookieSettings.sameSite = 'lax';
-    }
+// Module-level session middleware — shared by Express routes and Socket.io auth
+const sessionCookieSettings: session.CookieOptions = { secure: false, maxAge: 1000 * 60 * 60 * 24 };
+if (isDebug) {
+    sessionCookieSettings.sameSite = 'lax';
+}
 
-    app.use(
-        session({
-            secret: process.env.SESSION_SECRET || 'default_secret_key', // Replace in production
-            resave: false,
-            saveUninitialized: false,
-            cookie: sessionCookieSettings,
-            store: redisStore,
-        })
-    );
+export const sessionMiddleware = session({
+    secret: process.env.SESSION_SECRET || 'default_secret_key',
+    resave: false,
+    saveUninitialized: false,
+    cookie: sessionCookieSettings,
+    store: redisStore,
+});
+
+export const addAuthMiddleware = (app: Express) => {
+    app.use(sessionMiddleware);
 
     app.use('/json-api/*', async (req: Request, res: Response, next: NextFunction) => {
         const [authType, username] = await Promise.all([
@@ -228,5 +229,23 @@ router.post('/resetPassword', async (req: Request, res: Response) => {
 
     res.json({ status: true });
 });
+
+/**
+ * Socket.io middleware — rejects unauthenticated connections unless AUTH_TYPE is 'none'.
+ * Must be registered AFTER the sessionMiddleware io.use() wrapper so that
+ * socket.request.session is already populated.
+ */
+export const socketAuthMiddleware = async (
+    socket: { request: unknown },
+    next: (err?: Error) => void
+): Promise<void> => {
+    const req = socket.request as Request;
+    const authType = await configService.getParameter(IplayarrParameter.AUTH_TYPE);
+    if (authType === 'none' || req.session?.user) {
+        next();
+    } else {
+        next(new Error('Unauthorized'));
+    }
+};
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import { Server as SocketIOServer } from 'socket.io';
 
 import ApiRoute from './routes/ApiRoute';
-import AuthRoute, { addAuthMiddleware } from './routes/AuthRoute';
+import AuthRoute, { addAuthMiddleware, sessionMiddleware, socketAuthMiddleware } from './routes/AuthRoute';
 import JsonApiRoute from './routes/JsonApiRoute';
 import loggingService from './service/loggingService';
 import { redis } from './service/redis/redisService';
@@ -71,6 +71,13 @@ app.get('*', (req, res) => {
 const server: Server = http.createServer(app);
 
 const io = isDebug ? new SocketIOServer(server, { cors: {} }) : new SocketIOServer(server);
+
+// Socket.io auth: apply session cookie parsing, then check for authenticated user
+io.use((socket, next) => {
+    sessionMiddleware(socket.request as Request, {} as Response, next as NextFunction);
+});
+io.use(socketAuthMiddleware);
+
 socketService.registerIo(io);
 
 server.listen(port, () => {

--- a/tests/routes/AuthRoute.test.ts
+++ b/tests/routes/AuthRoute.test.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import session from 'express-session';
 import request from 'supertest';
 
-import AuthRoute, { addAuthMiddleware } from '../../src/routes/AuthRoute';
+import AuthRoute, { addAuthMiddleware, socketAuthMiddleware } from '../../src/routes/AuthRoute';
 import configService from '../../src/service/configService';
 import { IplayarrParameter } from '../../src/types/IplayarrParameters';
 import { ApiError } from '../../src/types/responses/ApiResponse';
@@ -196,5 +196,42 @@ describe('AuthRoute', () => {
             expect(res.status).toBe(200);
             expect(res.body).toEqual({ status: true });
         });
+    });
+});
+
+describe('socketAuthMiddleware', () => {
+    const makeSocket = (sessionData?: Record<string, any>) => ({
+        request: { session: sessionData ?? {} },
+    });
+
+    it('should allow connection when AUTH_TYPE is none', async () => {
+        (configService.getParameter as jest.Mock).mockResolvedValueOnce('none');
+        const next = jest.fn();
+
+        await socketAuthMiddleware(makeSocket() as any, next);
+
+        expect(next).toHaveBeenCalledWith(/* no error */);
+        expect(next.mock.calls[0]).toHaveLength(0);
+    });
+
+    it('should allow connection when user is present in session', async () => {
+        (configService.getParameter as jest.Mock).mockResolvedValueOnce('form');
+        const next = jest.fn();
+
+        await socketAuthMiddleware(makeSocket({ user: { username: 'haven' } }) as any, next);
+
+        expect(next).toHaveBeenCalledWith(/* no error */);
+        expect(next.mock.calls[0]).toHaveLength(0);
+    });
+
+    it('should reject connection when no session user and auth is required', async () => {
+        (configService.getParameter as jest.Mock).mockResolvedValueOnce('form');
+        const next = jest.fn();
+
+        await socketAuthMiddleware(makeSocket() as any, next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+        expect(next.mock.calls[0][0].message).toBe('Unauthorized');
     });
 });


### PR DESCRIPTION
### Description
This PR enforces session authentication middleware on WebSocket (Socket.io) connections to prevent unauthorized websocket connections from subscribing to internal application events or triggering tasks.

---
*Assisted by Google Antigravity AI agent.*